### PR TITLE
Fixing reader.core.entitydef 

### DIFF
--- a/pyapacheatlas/__init__.py
+++ b/pyapacheatlas/__init__.py
@@ -1,3 +1,3 @@
 from .readers import from_excel
 
-__version__ = "0.0.6"
+__version__ = "0.0.7"

--- a/pyapacheatlas/readers/core/entitydef.py
+++ b/pyapacheatlas/readers/core/entitydef.py
@@ -26,7 +26,13 @@ def to_entityDefs(json_rows):
 
         _ = row.pop("Entity TypeName")
         # Update all seen attribute metadata
-        attribute_metadata_seen = attribute_metadata_seen.union(set(row.keys()))
+        columns_in_row = list(row.keys())
+        attribute_metadata_seen = attribute_metadata_seen.union(set(columns_in_row))
+        # Remove any null cells, otherwise the AttributeDefs constructor
+        # doesn't use the defaults.
+        for column in columns_in_row:
+            if row[column] is None:
+                _ = row.pop(column)
 
         json_entity_def = AtlasAttributeDef(**row).to_json()
         


### PR DESCRIPTION
Fixing reader.core.entitydef  to ensure that blank/none values are given the default values as set up in AtlasAttributeDef