### PR TITLE
Adding Case Sensitivity to Reader

### DIFF
--- a/pyapacheatlas/readers/core/column.py
+++ b/pyapacheatlas/readers/core/column.py
@@ -31,15 +31,15 @@ def to_column_entities(json_rows, excel_config, guid_tracker, atlas_entities, at
     """
     # Required attributes
     # NOTE: Classification is not actually required but it's being included to avoid being roped in as an attribute
-    source_table_name_header = excel_config.entity_source_prefix + " table"
-    source_column_name_header = excel_config.entity_source_prefix + " column"
-    source_column_classifications_header = excel_config.entity_source_prefix + " classifications"
+    source_table_name_header = excel_config.entity_source_prefix + " Table"
+    source_column_name_header = excel_config.entity_source_prefix + " Column"
+    source_column_classifications_header = excel_config.entity_source_prefix + " Classifications"
     required_source_headers = [source_column_name_header,
                                source_table_name_header, source_column_classifications_header]
 
-    target_table_name_header = excel_config.entity_target_prefix + " table"
-    target_column_name_header = excel_config.entity_target_prefix + " column"
-    target_column_classifications_header = excel_config.entity_target_prefix + " classifications"
+    target_table_name_header = excel_config.entity_target_prefix + " Table"
+    target_column_name_header = excel_config.entity_target_prefix + " Column"
+    target_column_classifications_header = excel_config.entity_target_prefix + " Classifications"
     required_target_headers = [target_column_name_header,
                                target_table_name_header, target_column_classifications_header]
 

--- a/pyapacheatlas/readers/core/table.py
+++ b/pyapacheatlas/readers/core/table.py
@@ -22,20 +22,20 @@ def to_table_entities(json_rows, excel_config, guid_tracker):
     """
     # Required attributes
     # NOTE: Classification is not actually required but it's being included to avoid being roped in as an attribute
-    source_table_name_header = excel_config.entity_source_prefix + " table"
-    source_table_type_column = excel_config.entity_source_prefix + " type"
-    source_table_classifications_header = excel_config.entity_source_prefix + " classifications"
+    source_table_name_header = excel_config.entity_source_prefix + " Table"
+    source_table_type_column = excel_config.entity_source_prefix + " Type"
+    source_table_classifications_header = excel_config.entity_source_prefix + " Classifications"
     required_source_headers = [source_table_name_header,
                                source_table_type_column, source_table_classifications_header]
 
-    target_table_name_header = excel_config.entity_target_prefix + " table"
-    target_table_type_column = excel_config.entity_target_prefix + " type"
-    target_table_classifications_header = excel_config.entity_target_prefix + " classifications"
+    target_table_name_header = excel_config.entity_target_prefix + " Table"
+    target_table_type_column = excel_config.entity_target_prefix + " Type"
+    target_table_classifications_header = excel_config.entity_target_prefix + " Classifications"
     required_target_headers = [target_table_name_header,
                                target_table_type_column, target_table_classifications_header]
 
-    process_name_column = excel_config.entity_process_prefix + " name"
-    process_type_column = excel_config.entity_process_prefix + " type"
+    process_name_column = excel_config.entity_process_prefix + " Name"
+    process_type_column = excel_config.entity_process_prefix + " Type"
     required_process_headers = [process_name_column, process_type_column]
 
     # Read in all Source and Target entities

--- a/pyapacheatlas/readers/excel.py
+++ b/pyapacheatlas/readers/excel.py
@@ -49,13 +49,13 @@ class ExcelConfiguration():
         self.table_sheet = table_sheet
         self.entityDef_sheet = entityDef_sheet
         self.entity_source_prefix = kwargs.get(
-            "entity_source_prefix", "source").lower()
+            "entity_source_prefix", "Source")
         self.entity_target_prefix = kwargs.get(
-            "entity_target_prefix", "target").lower()
+            "entity_target_prefix", "Target")
         self.entity_process_prefix = kwargs.get(
-            "entity_process_prefix", "process").lower()
+            "entity_process_prefix", "Process")
         self.column_transformation_name = kwargs.get(
-            "column_transformation_name", "transformation").lower()
+            "column_transformation_name", "Transformation")
 
 
 def from_excel(filepath, excel_config, atlas_typedefs, use_column_mapping=False):
@@ -174,8 +174,7 @@ def excel_typeDefs(filepath, excel_config):
     # Getting entityDefinitions if the user provided a name of the sheet
     if excel_config.entityDef_sheet:
         entityDef_sheet = wb[excel_config.entityDef_sheet]
-        json_entitydefs = _parse_spreadsheet(
-            entityDef_sheet, lowercase_headers=False)
+        json_entitydefs = _parse_spreadsheet(entityDef_sheet)
         entityDefs_generated = to_entityDefs(json_entitydefs)
         output.update(entityDefs_generated)
 
@@ -183,17 +182,12 @@ def excel_typeDefs(filepath, excel_config):
     return output
 
 
-def _parse_spreadsheet(worksheet, lowercase_headers=True):
+def _parse_spreadsheet(worksheet):
     """
-    Standardizes the excel worksheet into a json format and lowercases
-    the column headers.
+    Standardizes the excel worksheet into a json format.
 
     :param openpyxl.workbook.Workbook worksheet:
         A worksheet class from openpyxl.
-    :param boolean lowercase_headers:
-        Whether headers in the excel spreadsheet should be lowercased.  This
-        is important for typeDefs pulling the exact attribute metadata from
-        the header.
     :return: The standardized version of the excel spreadsheet in json form.
     :rtype: list(dict(str,str))
     """
@@ -207,15 +201,9 @@ def _parse_spreadsheet(worksheet, lowercase_headers=True):
         )
     )
 
-    def _header_casing(s, lowercase=lowercase_headers):
-        if lowercase:
-            return s.lower()
-        else:
-            return s
-
     output = []
     for row in worksheet.iter_rows(min_row=2, max_row=worksheet.max_row, min_col=1, max_col=worksheet.max_column):
         output.append(
-            {_header_casing(k): row[idx].value for idx, k in column_headers})
+            {k: row[idx].value for idx, k in column_headers})
 
     return output

--- a/tests/readers/core/test_table_column.py
+++ b/tests/readers/core/test_table_column.py
@@ -15,17 +15,17 @@ EXCEL_CONFIG = ExcelConfiguration()
 def setupto_column_entities():
     json_tables = [
         {
-            "target table":"table1", "target type": "demo_table",
-            "source table":"table0", "source type": "demo_table",
-            "process name":"proc01", "process type": "demo_process"
+            "Target Table":"table1", "Target Type": "demo_table",
+            "Source Table":"table0", "Source Type": "demo_table",
+            "Process Name":"proc01", "Process Type": "demo_process"
         }
     ]
     
     json_columns = [
         {
-            "target column":"col1","target table": "table1",
-            "source column":"col0","source table": "table0",
-            "transformation":None
+            "Target Column":"col1","Target Table": "table1",
+            "Source Column":"col0","Source Table": "table0",
+            "Transformation":None
         }
     ]
 
@@ -50,9 +50,9 @@ def test_to_table_entities():
     guid_tracker = GuidTracker(-1000)
     json_rows = [
         {
-            "target table":"table1", "target type": "demo_type",
-            "source table":"table0", "source type": "demo_type2",
-            "process name":"proc01", "process type": "proc_type"
+            "Target Table":"table1", "Target Type": "demo_type",
+            "Source Table":"table0", "Source Type": "demo_type2",
+            "Process Name":"proc01", "Process Type": "proc_type"
         }
     ]
 
@@ -67,9 +67,9 @@ def test_to_table_entities_with_attributes():
     guid_tracker = GuidTracker(-1000)
     json_rows = [
         {
-            "target table":"table1", "target type": "demo_type","target data_type":"str",
-            "source table":"table0", "source type": "demo_type2","source foo":"bar",
-            "process name":"proc01", "process type": "proc_type", "process fizz":"buzz"
+            "Target Table":"table1", "Target Type": "demo_type","Target data_type":"str",
+            "Source Table":"table0", "Source Type": "demo_type2","Source foo":"bar",
+            "Process Name":"proc01", "Process Type": "proc_type", "Process fizz":"buzz"
         }
     ]
 
@@ -84,14 +84,14 @@ def test_to_table_entities_multiple_inputs():
     guid_tracker = GuidTracker(-1000)
     json_tables = [
         {
-            "target table":"table1", "target type": "demo_type",
-            "source table":"table0", "source type": "demo_type",
-            "process name":"proc01", "process type": "proc_type"
+            "Target Table":"table1", "Target Type": "demo_type",
+            "Source Table":"table0", "Source Type": "demo_type",
+            "Process Name":"proc01", "Process Type": "proc_type"
         },
         {
-            "target table":"table1", "target type": "demo_type",
-            "source table":"tableB", "source type": "demo_type",
-            "process name":"proc01", "process type": "proc_type"
+            "Target Table":"table1", "Target Type": "demo_type",
+            "Source Table":"tableB", "Source Type": "demo_type",
+            "Process Name":"proc01", "Process Type": "proc_type"
         }
     ]
 
@@ -150,7 +150,7 @@ def test_to_column_entities_with_attributes():
     json_tables, json_columns, atlas_typedefs = setupto_column_entities()
 
     # Update target to include an attribute
-    json_columns[0].update({"target test_attrib1":"value", "target test_attrib2":"value2", "source foo":"bar"})
+    json_columns[0].update({"Target test_attrib1":"value", "Target test_attrib2":"value2", "Source foo":"bar"})
     
     # Outputs -1003 as the last guid
     tables_and_processes = to_table_entities(json_tables, EXCEL_CONFIG, guid_tracker)
@@ -173,7 +173,7 @@ def test_to_column_entities_with_classifications():
     json_tables, json_columns, atlas_typedefs = setupto_column_entities()
 
     # Update target to include a classification
-    json_columns[0].update({"target classifications":"CustomerInfo; PII", "source classifications":""})
+    json_columns[0].update({"Target Classifications":"CustomerInfo; PII", "Source Classifications":""})
     
     # Outputs -1003 as the last guid
     tables_and_processes = to_table_entities(json_tables, EXCEL_CONFIG, guid_tracker)
@@ -198,7 +198,7 @@ def test_to_column_entities_with_attributes():
     json_tables, json_columns, atlas_typedefs = setupto_column_entities()
 
     # Update target to include an attribute
-    json_columns[0].update({"target test_attrib1":"value", "target test_attrib2":"value2", "source foo":"bar"})
+    json_columns[0].update({"Target test_attrib1":"value", "Target test_attrib2":"value2", "Source foo":"bar"})
     
     # Outputs -1003 as the last guid
     tables_and_processes = to_table_entities(json_tables, EXCEL_CONFIG, guid_tracker)
@@ -227,9 +227,9 @@ def test_to_column_entities_with_columnMapping():
     json_tables, json_columns, atlas_typedefs = setupto_column_entities()
 
     json_columns.append({
-            "target column":"col99","target table": "table1",
-            "source column":"col90","source table": "table0",
-            "transformation":"col90 + 1"
+            "Target Column":"col99","Target Table": "table1",
+            "Source Column":"col90","Source Table": "table0",
+            "Transformation":"col90 + 1"
         }
     )
     
@@ -249,18 +249,18 @@ def test_to_column_entities_when_multi_tabled_inputs():
     # Adding in an extra table
     json_tables.append(
         {
-            "target table":"table1", "target type": "demo_table",
-            "source table":"tableB", "source type": "demo_table",
-            "process name":"proc01", "process type": "demo_process"
+            "Target Table":"table1", "Target Type": "demo_table",
+            "Source Table":"tableB", "Source Type": "demo_table",
+            "Process Name":"proc01", "Process Type": "demo_process"
         }
     )
-    json_columns[0].update({"transformation":"colB + col0"})
+    json_columns[0].update({"Transformation":"colB + col0"})
     # Adding in an extra column
     json_columns.append(
         {
-            "target column":"col1","target table": "table1",
-            "source column":"colB","source table": "tableB",
-            "transformation":"colB + col0"
+            "Target Column":"col1","Target Table": "table1",
+            "Source Column":"colB","Source Table": "tableB",
+            "Transformation":"colB + col0"
         }
     )
     expected_col_map_obj = [


### PR DESCRIPTION
It turns out that the properties of an Atlas Entity are case sensitive.

Now the excel template reader does not attempt to standardize the column headers.
This has the downside that the Table, Column, Transformation, and Process columns
must be typed exactly as is.

However, now we get to have camelCasing in attributes work consistenly for
Tables, Columns, and EntityDefs tabs!