### PR TITLE
Support Non Lineage Entity Upload

### DIFF
--- a/pyapacheatlas/__init__.py
+++ b/pyapacheatlas/__init__.py
@@ -1,3 +1,3 @@
 from .readers import from_excel
 
-__version__ = "0.0.8"
+__version__ = "0.0b9"

--- a/pyapacheatlas/readers/core/__init__.py
+++ b/pyapacheatlas/readers/core/__init__.py
@@ -1,3 +1,4 @@
 from .column import to_column_entities
 from .table import to_table_entities
 from .entitydef import to_entityDefs
+from .bulkEntities import to_bulkEntities

--- a/pyapacheatlas/readers/core/bulkEntities.py
+++ b/pyapacheatlas/readers/core/bulkEntities.py
@@ -1,0 +1,40 @@
+from warnings import warn
+from ...core import AtlasEntity
+from ...core import GuidTracker
+from ...readers.util import string_to_classification
+
+
+def to_bulkEntities(json_rows, starting_guid=-1000):
+    """
+    Create an AtlasTypeDef consisting of entities and their attributes for the given json_rows.
+
+    :param list(dict(str,str)) json_rows:
+        A list of dicts containing at least `Entity TypeName` and `name`
+        that represents the metadata for a given entity type's attributeDefs.
+        Extra metadata will be ignored.
+    :return: An AtlasTypeDef with entityDefs for the provided rows.
+    :rtype: dict(str, list(dict))
+    """
+    # For each row,
+    # Extract the
+    # Extract any additional attributes
+    req_attribs = ["typeName", "name", "qualifiedName", "classifications"]
+    gt = GuidTracker(starting_guid)
+    output = {"entities": []}
+    for row in json_rows:
+        # Remove any cell with a None / Null attribute
+        # Remove the required attributes so they're not double dipping.
+        custom_attributes = {
+            k: v for k, v in row.items()
+            if k not in req_attribs and v is not None
+        }
+        entity = AtlasEntity(
+            name=row["name"],
+            typeName=row["typeName"],
+            qualified_name=row["qualifiedName"],
+            guid=gt.get_guid(),
+            attributes=custom_attributes,
+            classifications=string_to_classification(row["classifications"])
+        ).to_json()
+        output["entities"].append(entity)
+    return output

--- a/pyapacheatlas/scaffolding/templates/excel.py
+++ b/pyapacheatlas/scaffolding/templates/excel.py
@@ -19,6 +19,29 @@ ENTITYDEF_TEMPLATE = [
     "indexType", "isIndexable"
 ]
 
+BULKENTITY_TEMPLATE = [
+    "typeName", "name", "qualifiedName", "classifications"
+]
+
+def _update_sheet_headers(headers, worksheet):
+    """
+    For the given worksheet, make the first row equal to the list passed
+    in as the headers.
+
+    :param list headers: A list of column headers to use for this sheet.
+    :param worksheet:
+        The worksheet you are updating.
+    :type worksheet:
+        :class:`~openpyxl.worksheet.worksheet.Worksheet`
+    """
+    for idx, val in enumerate(headers):
+        # TODO: Not the best way once we get past 26 columns in the template
+        active_column = ascii_uppercase[idx]
+        active_value = headers[idx]
+        active_cell = "{}1".format(active_column)
+        worksheet[active_cell] = active_value
+        worksheet.column_dimensions[active_column].width = len(active_value)
+
 
 def excel_template(filepath):
     """
@@ -28,34 +51,16 @@ def excel_template(filepath):
         template Tables and Columns sheets.
     """
     wb = Workbook()
-    columns = wb.active
-    columns.title = "Columns"
-    tables = wb.create_sheet("Tables")
-    entityDefs = wb.create_sheet("EntityDefs")
+    columnsSheet = wb.active
+    columnsSheet.title = "ColumnsLineage"
+    tablesSheet = wb.create_sheet("TablesLineage")
+    entityDefsSheet = wb.create_sheet("EntityDefs")
+    bulkEntitiesSheet = wb.create_sheet("BulkEntities")
 
-    for idx, val in enumerate(COLUMN_TEMPLATE):
-        # TODO: Not the best way once we get past 26 columns in the template
-        active_column = ascii_uppercase[idx]
-        active_value = COLUMN_TEMPLATE[idx]
-        active_cell = "{}1".format(active_column)
-        columns[active_cell] = active_value
-        columns.column_dimensions[active_column].width = len(active_value)
-
-    for idx, val in enumerate(TABLE_TEMPLATE):
-        # TODO: Not the best way once we get past 26 columns in the template
-        active_column = ascii_uppercase[idx]
-        active_value = TABLE_TEMPLATE[idx]
-        active_cell = "{}1".format(active_column)
-        tables[active_cell] = active_value
-        tables.column_dimensions[active_column].width = len(active_value)
-
-    for idx, val in enumerate(ENTITYDEF_TEMPLATE):
-        # TODO: Not the best way once we get past 26 columns in the template
-        active_column = ascii_uppercase[idx]
-        active_value = ENTITYDEF_TEMPLATE[idx]
-        active_cell = "{}1".format(active_column)
-        entityDefs[active_cell] = active_value
-        entityDefs.column_dimensions[active_column].width = len(active_value)
+    _update_sheet_headers(COLUMN_TEMPLATE, columnsSheet)
+    _update_sheet_headers(TABLE_TEMPLATE, tablesSheet)
+    _update_sheet_headers(ENTITYDEF_TEMPLATE, entityDefsSheet)
+    _update_sheet_headers(BULKENTITY_TEMPLATE, bulkEntitiesSheet)
 
     wb.save(filepath)
     wb.close()

--- a/samples/end_to_end_excel_sample.py
+++ b/samples/end_to_end_excel_sample.py
@@ -6,13 +6,17 @@ from openpyxl import Workbook
 from openpyxl import load_workbook
 
 # PyApacheAtlas packages
-from pyapacheatlas.auth import ServicePrincipalAuthentication # Connect to Atlas via a Service Principal
-from pyapacheatlas.core import AtlasClient # Communicate with your Atlas server
-from pyapacheatlas.scaffolding import column_lineage_scaffold # Create dummy types
-from pyapacheatlas.scaffolding.templates import excel_template # Create the excel template file to be populated
-from pyapacheatlas.readers import from_excel # Read in the populated excel file.
-from pyapacheatlas.readers.excel import ExcelConfiguration # Customize header prefixes (e.g. "Sink" rather than "Target") and sheet names
-from pyapacheatlas.core.whatif import WhatIfValidator # To do what if analysis
+# Connect to Atlas via a Service Principal
+from pyapacheatlas.auth import ServicePrincipalAuthentication
+from pyapacheatlas.core import AtlasClient  # Communicate with your Atlas server
+from pyapacheatlas.scaffolding import column_lineage_scaffold  # Create dummy types
+# Create the excel template file to be populated
+from pyapacheatlas.scaffolding.templates import excel_template
+# Read in the populated excel file.
+from pyapacheatlas.readers import from_excel
+# Customize header prefixes (e.g. "Sink" rather than "Target") and sheet names
+from pyapacheatlas.readers.excel import ExcelConfiguration
+from pyapacheatlas.core.whatif import WhatIfValidator  # To do what if analysis
 
 if __name__ == "__main__":
     """
@@ -23,22 +27,23 @@ if __name__ == "__main__":
 
     # Authenticate against your Atlas server
     oauth = ServicePrincipalAuthentication(
-        tenant_id = os.environ.get("TENANT_ID", ""),
-        client_id = os.environ.get("CLIENT_ID", ""),
-        client_secret = os.environ.get("CLIENT_SECRET", "")
+        tenant_id=os.environ.get("TENANT_ID", ""),
+        client_id=os.environ.get("CLIENT_ID", ""),
+        client_secret=os.environ.get("CLIENT_SECRET", "")
     )
     client = AtlasClient(
-        endpoint_url =  os.environ.get("ENDPOINT_URL", ""),
-        authentication = oauth
+        endpoint_url=os.environ.get("ENDPOINT_URL", ""),
+        authentication=oauth
     )
 
     # Create an empty excel template to be populated
     file_path = "./atlas_excel_template.xlsx"
+    excel_config = ExcelConfiguration()
     excel_template(file_path)
 
     wb = load_workbook(file_path)
-    table_sheet = wb["Tables"]
-    columns_sheet = wb["Columns"]
+    table_sheet = wb[excel_config.table_sheet]
+    columns_sheet = wb[excel_config.column_sheet]
 
     # TABLE Sheet SCHEMA
     # "Target Table", "Target Type", "Target Classifications",
@@ -46,77 +51,98 @@ if __name__ == "__main__":
     # "Process Name", "Process Type"
     # LIMITATION: Does not support multiple outputs from same process
     tables_to_load = [
-        ["DestTable01", "demo_table", None, "SourceTable01", "demo_table", None, "Daily_ETL", "demo_process"],
-        ["DestTable01", "demo_table", None, "SourceTable02", "demo_table", None, "Daily_ETL", "demo_process"],
-        ["DestTable02", "demo_table", None, "SourceTable03", "demo_table", None, "Weekly_ETL", "demo_process"],
-        ["DestTable03", "demo_table", None, None, None, None, "Stored_Proc:Do_Something", "demo_process"]
+        ["DestTable01", "demo_table", None, "SourceTable01",
+            "demo_table", None, "Daily_ETL", "demo_process"],
+        ["DestTable01", "demo_table", None, "SourceTable02",
+            "demo_table", None, "Daily_ETL", "demo_process"],
+        ["DestTable02", "demo_table", None, "SourceTable03",
+            "demo_table", None, "Weekly_ETL", "demo_process"],
+        ["DestTable03", "demo_table", None, None, None,
+            None, "Stored_Proc:Do_Something", "demo_process"]
     ]
     # COLUMNS Sheet SCHEMA
     # "Target Table", "Target Column", "Target Classifications",
     # "Source Table", "Source Column", "Source Classifications",
     # "Transformation"
     columns_to_load = [
-        ["DestTable01", "dest_c01", None, "SourceTable01", "source_c01", None, None],
-        ["DestTable01", "dest_c02", None, "SourceTable01", "source_c02", None, None],
+        ["DestTable01", "dest_c01", None, "SourceTable01", "source_c01",
+         None, None],
+        ["DestTable01", "dest_c02", None, "SourceTable01", "source_c02",
+         None, None],
         # Demonstrate the ability to merge multiple columns
-        ["DestTable01", "dest_combo01", None, "SourceTable01", "source_c03", None, "source_c03 + source_c04"],
-        ["DestTable01", "dest_combo01", None, "SourceTable02", "source_c04", None, "source_c03 + source_c04"],
+        ["DestTable01", "dest_combo01", None, "SourceTable01",
+            "source_c03", None, "source_c03 + source_c04"],
+        ["DestTable01", "dest_combo01", None, "SourceTable02",
+            "source_c04", None, "source_c03 + source_c04"],
         # Demonstrate a simple, straightforward table with classifications
-        ["DestTable02", "dest_c03", None, "SourceTable03", "source_c05", "MICROSOFT.PERSONAL.IPADDRESS", None],
-        ["DestTable02", "dest_c04_express", None, None, None, None, "CURRENT_TIMESTAMP()"],
+        ["DestTable02", "dest_c03", None, "SourceTable03",
+            "source_c05", "MICROSOFT.PERSONAL.IPADDRESS", None],
+        ["DestTable02", "dest_c04_express", None,
+            None, None, None, "CURRENT_TIMESTAMP()"],
         # Demonstrate a table with no sources at all
-        ["DestTable03", "dest_c100_express", None, None, None, None, "CURRENT_TIMESTAMP()"],
-        ["DestTable03", "dest_c101_express", None, None, None, None, "RAND(100)"],
-        ["DestTable03", "dest_c102_notransform", None, None, None, None, None],
+        ["DestTable03", "dest_c100_express", None,
+            None, None, None, "CURRENT_TIMESTAMP()"],
+        ["DestTable03", "dest_c101_express",
+            None, None, None, None, "RAND(100)"],
+        ["DestTable03", "dest_c102_notransform", None, None, None,
+         None, None],
     ]
-    
+
     # Populate the excel template with samples above
     table_row_counter = 0
-    for row in table_sheet.iter_rows(min_row=2, max_col=8, max_row= len(tables_to_load)+1):
+    for row in table_sheet.iter_rows(min_row=2, max_col=8,
+                                     max_row=len(tables_to_load) + 1):
         for idx, cell in enumerate(row):
             cell.value = tables_to_load[table_row_counter][idx]
         table_row_counter += 1
-    
+
     column_row_counter = 0
-    for row in columns_sheet.iter_rows(min_row=2, max_col=7, max_row= len(columns_to_load)+1):
+    for row in columns_sheet.iter_rows(min_row=2, max_col=7,
+                                       max_row=len(columns_to_load) + 1):
         for idx, cell in enumerate(row):
             cell.value = columns_to_load[column_row_counter][idx]
         column_row_counter += 1
-        
+
     wb.save(file_path)
 
     # Generate the base atlas type defs for the demo of table and column lineage
-    atlas_type_defs = column_lineage_scaffold("demo", use_column_mapping=True,
-    column_attributes=[{
-        "name":"datatype",
-        "typeName": "string",
-        "isOptional":True, 
-        "cardinality":"SINGLE",
-        "valuesMinCount": 1,
-        "valuesMaxCount": 1,
-        "isUnique": False,
-        "isIndexable": False,
-        "includeInNotification": False
-    }]
+    atlas_type_defs = column_lineage_scaffold(
+        "demo", use_column_mapping=True,
+        column_attributes=[{
+            "name": "datatype",
+            "typeName": "string",
+            "isOptional": True,
+            "cardinality": "SINGLE",
+            "valuesMinCount": 1,
+            "valuesMaxCount": 1,
+            "isUnique": False,
+            "isIndexable": False,
+            "includeInNotification": False
+        }]
     )
-    # Alternatively, you can get all atlas types if you've  via...
+    # Alternatively, you can get all atlas types via...
     # atlas_type_defs = client.get_all_typedefs()
+
     # Upload scaffolded type defs and view the results of upload
-    _upload_typedef = client.upload_typedefs(atlas_type_defs, force_update=False)
-    # print(json.dumps(_upload_typedef,indent=2))
+    _upload_typedef = client.upload_typedefs(
+        atlas_type_defs, 
+        force_update=False
+    )
+    print(json.dumps(_upload_typedef,indent=2))
 
     # Instantiate some required objects and generate the atlas entities!
-    excel_config = ExcelConfiguration()
-    excel_results = from_excel(file_path, excel_config, atlas_type_defs, use_column_mapping=True)
+
+    excel_results = from_excel(
+        file_path, excel_config, atlas_type_defs, use_column_mapping=True)
 
     print("Results from excel transformation")
     print(json.dumps(excel_results, indent=2))
 
     # Validate What IF
     whatif = WhatIfValidator(type_defs=atlas_type_defs)
-    
+
     report = whatif.validate_entities(excel_results)
-    
+
     if report["total"] > 0:
         print("There were errors in the provided typedefs")
         print(json.dumps(report))
@@ -124,7 +150,6 @@ if __name__ == "__main__":
     else:
         print("There were no errors in the excel file")
 
-    
     # Upload excel file's content to Atlas and view the guid assignments to confirm successful upload
     uploaded_entities = client.upload_entities(excel_results)
     print(json.dumps(uploaded_entities, indent=2))

--- a/tests/readers/test_excel.py
+++ b/tests/readers/test_excel.py
@@ -7,12 +7,33 @@ from openpyxl import load_workbook
 
 from pyapacheatlas.scaffolding.templates.excel import (
     excel_template,
-    ENTITYDEF_TEMPLATE
+    ENTITYDEF_TEMPLATE,
+    BULKENTITY_TEMPLATE
 )
 from pyapacheatlas.readers.excel import (
     ExcelConfiguration,
+    excel_bulkEntities,
     excel_typeDefs
 )
+
+from pyapacheatlas.scaffolding.templates.excel import _update_sheet_headers
+
+
+def setup_workbook_custom_sheet(filepath, sheet_name, headers, json_rows):
+    wb = Workbook()
+    customSheet = wb.active
+    customSheet.title = sheet_name
+    _update_sheet_headers(headers, customSheet)
+    row_counter = 0
+    # Add the data to the sheet
+    for row in customSheet.iter_rows(min_row=2, max_col=len(headers), max_row=len(json_rows)+1):
+        for idx, cell in enumerate(row):
+            cell.value = json_rows[row_counter][idx]
+        row_counter += 1
+
+    wb.save(filepath)
+    wb.close()
+
 
 def setup_workbook(filepath, sheet_name, max_col, json_rows):
     excel_template(filepath)
@@ -21,11 +42,11 @@ def setup_workbook(filepath, sheet_name, max_col, json_rows):
 
     row_counter = 0
     # TODO: Make the max_col more dynamic
-    for row in active_sheet.iter_rows(min_row=2, max_col=max_col, max_row= len(json_rows)+1):
+    for row in active_sheet.iter_rows(min_row=2, max_col=max_col, max_row=len(json_rows)+1):
         for idx, cell in enumerate(row):
             cell.value = json_rows[row_counter][idx]
         row_counter += 1
-    
+
     wb.save(filepath)
 
 
@@ -44,14 +65,14 @@ def test_excel_typeDefs_entityTypes():
     # "valuesMaxCount", "cardinality", "includeInNotification",
     # "indexType", "isIndexable"
     json_rows = [
-        ["demoType", "attrib1", "Some desc", 
-        "True", "False", None,
-        "string", None, None,
-        None, None, None,
-        None, None
-        ]
+        ["demoType", "attrib1", "Some desc",
+         "True", "False", None,
+         "string", None, None,
+         None, None, None,
+         None, None
+         ]
     ]
-    setup_workbook(temp_filepath,"EntityDefs", max_cols, json_rows )
+    setup_workbook(temp_filepath, "EntityDefs", max_cols, json_rows)
 
     results = excel_typeDefs(temp_filepath, ec)
 
@@ -60,3 +81,108 @@ def test_excel_typeDefs_entityTypes():
     assert(results["entityDefs"][0]["attributeDefs"][0]["name"] == "attrib1")
 
     remove_workbook(temp_filepath)
+
+
+def test_excel_bulkEntities():
+    temp_filepath = "./temp_test_excel_bulkEntities.xlsx"
+    ec = ExcelConfiguration()
+    max_cols = len(BULKENTITY_TEMPLATE)
+    # "typeName", "name",
+    # "qualifiedName", "classifications"
+    json_rows = [
+        ["demoType", "entityNameABC",
+         "qualifiedNameofEntityNameABC", None
+         ],
+        ["demoType", "entityNameGHI",
+         "qualifiedNameofEntityNameGHI", None
+         ]
+    ]
+    setup_workbook(temp_filepath, "BulkEntities", max_cols, json_rows)
+
+    results = excel_bulkEntities(temp_filepath, ec)
+
+    try:
+        assert("entities" in results)
+        assert(len(results["entities"]) == 2)
+    finally:
+        remove_workbook(temp_filepath)
+
+
+def test_excel_bulkEntities_withClassifications():
+    temp_filepath = "./temp_test_excel_bulkEntitiesWithClassifications.xlsx"
+    ec = ExcelConfiguration()
+    max_cols = len(BULKENTITY_TEMPLATE)
+    # "typeName", "name",
+    # "qualifiedName", "classifications"
+    json_rows = [
+        ["demoType", "entityNameABC",
+         "qualifiedNameofEntityNameABC", "PII"
+         ],
+        ["demoType", "entityNameGHI",
+         "qualifiedNameofEntityNameGHI", "PII;CLASS2"
+         ]
+    ]
+
+    setup_workbook(temp_filepath, "BulkEntities", max_cols, json_rows)
+
+    results = excel_bulkEntities(temp_filepath, ec)
+
+    try:
+        assert("entities" in results)
+        assert(len(results["entities"]) == 2)
+        abc = results["entities"][0]
+        ghi = results["entities"][1]
+
+        assert(len(abc["classifications"]) == 1)
+        assert(len(ghi["classifications"]) == 2)
+
+        assert(abc["classifications"][0]["typeName"] == "PII")
+        ghi_classification_types = set(
+            [x["typeName"] for x in ghi["classifications"]]
+        )
+        assert(set(["PII", "CLASS2"]) == ghi_classification_types)
+    finally:
+        remove_workbook(temp_filepath)
+
+
+def test_excel_bulkEntities_dynamicAttributes():
+    temp_filepath = "./temp_test_excel_bulkEntitieswithAttributes.xlsx"
+    ec = ExcelConfiguration()
+
+    headers = BULKENTITY_TEMPLATE + ["attrib1", "attrib2"]
+    # "typeName", "name",
+    # "qualifiedName", "classifications"
+    # "attrib1", "attrib2"
+    json_rows = [
+        ["demoType", "entityNameABC",
+         "qualifiedNameofEntityNameABC", None,
+         None, "abc"
+         ],
+        ["demoType", "entityNameGHI",
+         "qualifiedNameofEntityNameGHI", None,
+         "ghi", "abc2"
+         ]
+    ]
+
+    setup_workbook_custom_sheet(
+        temp_filepath, "BulkEntities", headers, json_rows)
+
+    results = excel_bulkEntities(temp_filepath, ec)
+
+    try:
+        assert("entities" in results)
+        assert(len(results["entities"]) == 2)
+        abc = results["entities"][0]
+        ghi = results["entities"][1]
+
+        assert("attrib1" not in abc["attributes"])
+        assert("attrib2" in abc["attributes"])
+        assert(abc["attributes"]["attrib2"] == "abc")
+
+        assert("attrib1" in ghi["attributes"])
+        assert("attrib2" in ghi["attributes"])
+        assert(ghi["attributes"]["attrib2"] == "abc2")
+        assert(ghi["attributes"]["attrib1"] == "ghi")
+
+    finally:
+        remove_workbook(temp_filepath)

--- a/tests/scaffolding/test_excel_template.py
+++ b/tests/scaffolding/test_excel_template.py
@@ -1,0 +1,24 @@
+import os
+
+from openpyxl import load_workbook
+
+from pyapacheatlas.scaffolding.templates import excel_template
+
+def test_verify_template_sheets():
+    # Setup
+    temp_path = "./temp_verfiysheets.xlsx"
+    excel_template(temp_path)
+
+    # Expected
+    expected_sheets = set(["ColumnsLineage", "TablesLineage", 
+        "EntityDefs", "BulkEntities"
+    ])
+
+    wb = load_workbook(temp_path)
+    difference = set(wb.sheetnames).symmetric_difference(expected_sheets)
+    try:
+        assert(len(difference) == 0)
+    finally:
+        wb.close()
+        os.remove(temp_path)
+


### PR DESCRIPTION
Closes #29 by adding the readers.core.bulkEntities function that takes in
a json entity and transforms to an Atlas Entity.  Four columns are
required "typeName", "name", "qualifiedName", "classifications" and any
additional attributes / columns added are automatically added as
attributes to the entity.  If a cell is empty for a given row, it is
not added to the entity.  This way you can mix entity types in a single
sheet and not risk adding invalid attributes.

In addition in readers.excel an excel_bulkEntities function takes in a
sheet and parses it to entities.  It wraps the readers.core.bulkEntities.

A breaking change to older versions (pre 0.0b9) is introduced as the
defaults in the excel template now change to:
* ColumnsLineage from Columns
* TablesLineage from Tables
* BulkEntities is added for this feature
* EntityDefs is unchanged

This was necessary to help distinguish between the lineage section and
the bulk entity uploads that some users may want to do instead.

However, this doesn't solve the challenge of relationship attributes.
If you do want to upload a table and column entity (with no lineage)
this feature does not currently support that mapping.

Need to figure out an elegant way to distinguish between an attribute
and a relationship attribute (e.g. specifying the table entity for a
column).