### PR TITLE
Abstract away pagination

### DIFF
--- a/pyapacheatlas/core/client.py
+++ b/pyapacheatlas/core/client.py
@@ -991,12 +991,12 @@ class AtlasClient():
 
         return results
 
-    def _search_generator(self, search_params):
+    def _search_generator(self, search_params, starting_offset=0):
         """
         Generator to page through the search query results.
         """
         atlas_endpoint = self.endpoint_url + "/search/advanced"
-        offset = 0
+        offset = starting_offset
 
         while True:
             postSearchResults = requests.post(
@@ -1019,7 +1019,7 @@ class AtlasClient():
                 return
 
     @PurviewOnly
-    def search_entities(self, query, limit=50, search_filter=None):
+    def search_entities(self, query, limit=50, search_filter=None, starting_offset=0):
         """
         Search entities based on a query and automaticall handles limits and
         offsets to page through results.
@@ -1053,7 +1053,7 @@ class AtlasClient():
             # {"filter": {"typeName": "DataSet", "includeSubTypes": True} }
             search_params.update({"filter": search_filter})
 
-        search_generator = self._search_generator(search_params)
+        search_generator = self._search_generator(search_params, starting_offset=starting_offset)
 
         return search_generator
 

--- a/pyapacheatlas/core/client.py
+++ b/pyapacheatlas/core/client.py
@@ -1013,10 +1013,12 @@ class AtlasClient():
 
             offset = offset + return_count
             search_params["offset"] = offset
-            try:
-                yield return_values
-            except StopIteration:
-                return
+            
+            for sub_result in return_values:
+                try:
+                    yield sub_result
+                except StopIteration:
+                    return
 
     @PurviewOnly
     def search_entities(self, query, limit=50, search_filter=None, starting_offset=0):
@@ -1033,7 +1035,7 @@ class AtlasClient():
             return for each page of the search results.
         :param dict search_filter: A search filter to reduce your results.
         :return: The results of your search as a generator.
-        :rtype: Iterator(list(dict))
+        :rtype: Iterator(dict)
         """
 
         if limit > 1000 or limit < 1:

--- a/tests/integration/test_search.py
+++ b/tests/integration/test_search.py
@@ -33,10 +33,9 @@ def test_purview_search_iterates_safely():
     search_results = client.search_entities(r"custom_type_entity")
 
     counter = 0
-    for page in search_results:
-        for entity in page:
-            len(entity["id"])
-            counter = counter + 1
+    for entity in search_results:
+        len(entity["id"])
+        counter = counter + 1
     
     assert(counter == 1)
 
@@ -61,10 +60,9 @@ def test_purview_search_iterates_safely_over_multiple():
     search_results = client.search_entities(r"there_can_be_only_two")
 
     counter = 0
-    for page in search_results:
-        for entity in page:
-            len(entity["id"])
-            counter = counter + 1
+    for entity in search_results:
+        len(entity["id"])
+        counter = counter + 1
     
     assert(counter == 2)
 
@@ -82,10 +80,9 @@ def test_purview_search_iterates_safely_over_none():
     search_results = client.search_entities(r"this_should_never_exist")
 
     counter = 0
-    for page in search_results:
-        for entity in page:
-            len(entity["id"])
-            counter = counter + 1
+    for entity in search_results:
+        len(entity["id"])
+        counter = counter + 1
     
     assert(counter == 0)
 


### PR DESCRIPTION
Instead of returning batches of matching Entities, it might be more user-friendly to return all results as single stream.

Also exposing the offset to the user in case of client-side pagination