### PR TITLE
Supporting the bulk Import and Export of Glossary Terms with CSVs

### DIFF
--- a/pyapacheatlas/core/client.py
+++ b/pyapacheatlas/core/client.py
@@ -1080,9 +1080,26 @@ class PurviewClient(AtlasClient):
         super().__init__(endpoint_url, authentication)
     
     @PurviewOnly
-    def import_terms(self, terms, glossary_name="Glossary", glossary_guid=None):
+    def import_terms(self, terms_path, glossary_name="Glossary", glossary_guid=None):
         # If you've got the guid: POST /atlas/v2/glossary/{glossaryGuid}/terms/import
         # If you don't have the guid: POST /atlas/v2/glossary/name/{glossaryName}/terms/import
+        results = None
+        if glossary_guid:
+            atlas_endpoint = self.endpoint_url + f"/glossary/{glossary_guid}/terms/import"
+        elif glossary_name:
+            atlas_endpoint = self.endpoint_url + f"/glossary/name/{glossary_name}/terms/import"
+        else:
+            raise ValueError("Either glossary_name or glossary_guid must be defined.")
+
+        postResp = requests.post(
+            atlas_endpoint,
+            files = {'file': open(terms_path, 'rb')},
+            headers=self.authentication.get_authentication_headers()
+        )
+
+        results = self._handle_response(postResp)
+
+        return results
 
         # file: file Name,Definition,Status,Related Terms,Synonyms,Acronym,Experts,Stewards
         # Term Templates are
@@ -1099,9 +1116,19 @@ class PurviewClient(AtlasClient):
         pass
 
     @PurviewOnly
-    def import_terms_status(self, operationGuid):
+    def import_terms_status(self, operation_guid):
         # GET /atlas/v2/glossary/terms/import/{operationGuid}
-        pass
+        results = None
+        atlas_endpoint = self.endpoint_url + f"/glossary/terms/import/{operation_guid}"
+
+        postResp = requests.get(
+            atlas_endpoint,
+            headers=self.authentication.get_authentication_headers()
+        )
+
+        results = self._handle_response(postResp)
+
+        return results
 
     @PurviewOnly
     def export_terms(self, guids, name="Glossary"):

--- a/pyapacheatlas/core/client.py
+++ b/pyapacheatlas/core/client.py
@@ -968,7 +968,10 @@ class AtlasClient():
 
     def upload_terms(self, batch, force_update=False):
         """
-        Upload terms to your Atlas backed Data Catalog.
+        Upload terms to your Atlas backed Data Catalog. Supports Purview Term
+        Templates by passing in an attributes field with the term template's
+        name as a field within attributes and an object of the required and
+        optional fields.
 
         :param batch: A list of AtlasGlossaryTerm objects to be uploaded.
         :type batch: list(dict)
@@ -1075,3 +1078,34 @@ class PurviewClient(AtlasClient):
     def __init__(self, account_name, authentication=None):
         endpoint_url = f"https://{account_name.lower()}.catalog.purview.azure.com/api/atlas/v2"
         super().__init__(endpoint_url, authentication)
+    
+    @PurviewOnly
+    def import_terms(self, terms, glossary_name="Glossary", glossary_guid=None):
+        # If you've got the guid: POST /atlas/v2/glossary/{glossaryGuid}/terms/import
+        # If you don't have the guid: POST /atlas/v2/glossary/name/{glossaryName}/terms/import
+
+        # file: file Name,Definition,Status,Related Terms,Synonyms,Acronym,Experts,Stewards
+        # Term Templates are
+
+        # 202 Accepted
+        # json_ImportCSVOperation
+        # Accepted. A job to import glossary terms via csv has been accepted.
+
+        # 400 Bad Request
+        # If csv file is not valid
+
+        # 404 Not Found
+        # If glossary GUID is invalid.
+        pass
+
+    @PurviewOnly
+    def import_terms_status(self, operationGuid):
+        # GET /atlas/v2/glossary/terms/import/{operationGuid}
+        pass
+
+    @PurviewOnly
+    def export_terms(self, guids, name="Glossary"):
+        """
+        :param list(str) guids: List of guids that should be exported as csv.
+        """
+        pass


### PR DESCRIPTION
Added support for the following endpoints as Purview Only methods.

* /glossary/{glossary_guid}/terms/export Export the terms to a given csv path.
* /glossary/terms/import/{operation_guid} Check the status of an import of terms.
* /glossary/{glossary_guid}/terms/import Import a given csv.
* /glossary/name/{glossary_name}/terms/import Import a given csv.

This enables users to take the same csvs they upload through the UI as through this package!