### PR TITLE
Updated token expiration property for Issue #89

### DIFF
--- a/pyapacheatlas/auth/serviceprincipal.py
+++ b/pyapacheatlas/auth/serviceprincipal.py
@@ -45,7 +45,7 @@ class ServicePrincipalAuthentication(AtlasAuthBase):
         authJson = json.loads(authResponse.text)
 
         self.access_token = authJson["access_token"]
-        self.expiration = datetime.fromtimestamp(int(authJson["expires_in"]))
+        self.expiration = datetime.fromtimestamp(int(authJson["expires_on"]))
 
     def get_authentication_headers(self):
         """


### PR DESCRIPTION
Using a datetime.fromtimestamp was throwing an error on Python3.6 on Windows in a Powershell environment. I think the correct field to be using is "expires_on" which is a timestamp versus "expires_in" which is an integer time difference.