### PR TITLE
Fix to delete_entity sample

### DIFF
--- a/samples/CRUD/delete_entity.py
+++ b/samples/CRUD/delete_entity.py
@@ -34,7 +34,6 @@ if __name__ == "__main__":
     )
 
     for entity in entities.get("entities"):
-        response = PurviewClient.delete_entity(guid=entity["guid"])
-        guid = response["guid"]
+        guid = entity["guid"]
         delete_response = client.delete_entity(guid=guid)
         print(json.dumps(delete_response, indent=2))


### PR DESCRIPTION
Have not been able to run the current sample as-is. Removing the first call to delete_entity and grabbing the GUID from the entity makes it work though.