### PR TITLE
Support Excel Classification Defs and Entity Def SuperTypes

### DIFF
--- a/pyapacheatlas/core/typedef.py
+++ b/pyapacheatlas/core/typedef.py
@@ -225,7 +225,7 @@ class ClassificationTypeDef(AtlasStructDef):
         self.subTypes = kwargs.get("subTypes", []) or []
 
     def __str__(self):
-        return self.name
+        return "<CLASSIFICATION: " + self.name + ">"
 
 
 class EntityTypeDef(AtlasStructDef):

--- a/pyapacheatlas/readers/reader.py
+++ b/pyapacheatlas/readers/reader.py
@@ -55,6 +55,9 @@ class Reader(LineageMixIn):
             "valuesMaxCount", "cardinality", "includeInNotification",
             "indexType", "isIndexable"
         ],
+        "ClassificationDefs": [
+            "classificationName", "entityTypes", "description"
+        ],
         "BulkEntities": [
             "typeName", "name", "qualifiedName", "classifications"
         ],

--- a/pyapacheatlas/readers/reader.py
+++ b/pyapacheatlas/readers/reader.py
@@ -192,7 +192,19 @@ class Reader(LineageMixIn):
     def parse_entity_defs(self, json_rows):
         """
         Create an AtlasTypeDef consisting of entityDefs for the
-        given json_rows.
+        given json_rows.  The columns `Entity TypeName` and `Entity superTypes`
+        are special and map to typeName and superTypes respectively.
+
+        Entity TypeName must be repeated for each row that has a relevant
+        attribute being defined on it. For example, if you plan on including
+        five attributes for type X, you would need to have five rows and
+        each row would have to fill in the Entity TypeName column.
+
+        superTypes can be specified all in one cell (default delimiter is `;`
+        and is controlled by the Reader's configuration) or across multiple
+        cells. If you specify DataSet in one row for type X and hive_table
+        for type X in a second row, it will result in a superType
+        of `[DataSet, hive_table]`.
 
         :param list(dict(str,str)) json_rows:
             A list of dicts containing at least `Entity TypeName` and `name`
@@ -202,8 +214,11 @@ class Reader(LineageMixIn):
         :rtype: dict(str, list(dict))
         """
         entities = dict()
+        entities_to_superTypes = dict()
         attribute_metadata_seen = set()
         output = {"entityDefs": []}
+
+        splitter = lambda attrib: [e for e in attrib.split(self.config.value_separator) if e]
         # Required attributes
         # Get all the attributes it's expecting official camel casing
         # with the exception of "Entity TypeName"
@@ -214,6 +229,24 @@ class Reader(LineageMixIn):
                 raise KeyError("Entity TypeName not found in {}".format(row))
 
             _ = row.pop("Entity TypeName")
+            
+            # If the user wants to add super types, they might be adding
+            # multiple on each row. They DON'T NEED TO but they might
+            entitySuperTypes = []
+            if "Entity superTypes" in row:
+                superTypes_string = row.pop("Entity superTypes")
+                # Might return a None or empty string
+                if superTypes_string:
+                    entitySuperTypes = splitter(superTypes_string)
+            
+            # Need to add this entity to the superTypes mapping if it doesn't
+            # already exist
+            if entityTypeName in entities_to_superTypes:
+                entities_to_superTypes[entityTypeName].extend(entitySuperTypes)
+            else:
+                entities_to_superTypes[entityTypeName] = entitySuperTypes
+            
+                
             # Update all seen attribute metadata
             columns_in_row = list(row.keys())
             attribute_metadata_seen = attribute_metadata_seen.union(
@@ -224,21 +257,27 @@ class Reader(LineageMixIn):
                 if row[column] is None:
                     _ = row.pop(column)
 
-            json_entity_def = AtlasAttributeDef(**row).to_json()
+            json_attribute_def = AtlasAttributeDef(**row).to_json()
 
             if entityTypeName not in entities:
                 entities[entityTypeName] = []
 
-            entities[entityTypeName].append(json_entity_def)
+            entities[entityTypeName].append( json_attribute_def )
 
         # Create the entitydefs
         for entityType in entities:
+            # Handle super types by de-duping, removing Nones / empty str and
+            # defaulting to ["DataSet"] if no user input super Types
+            all_super_types = [t for t in set(entities_to_superTypes[entityType]) if t]
+            if len(all_super_types) == 0:
+                all_super_types = ["DataSet"]
+
             local_entity_def = EntityTypeDef(
                 name=entityType,
                 attributeDefs=entities[entityType],
                 # Adding this as a default until I figure
                 # do this from the excel / json readers.
-                superTypes=["DataSet"]
+                superTypes=all_super_types
             ).to_json()
             output["entityDefs"].append(local_entity_def)
 

--- a/tests/unit/readers/test_excel.py
+++ b/tests/unit/readers/test_excel.py
@@ -10,6 +10,7 @@ from openpyxl import load_workbook
 from pyapacheatlas.readers.excel import ExcelConfiguration, ExcelReader
 from pyapacheatlas.scaffolding.column_lineage import column_lineage_scaffold
 
+
 def test_verify_template_sheets():
     # Setup
     temp_path = "./temp_verfiysheets.xlsx"
@@ -18,7 +19,7 @@ def test_verify_template_sheets():
     # Expected
     expected_sheets = set(["ColumnsLineage", "TablesLineage",
                            "EntityDefs", "BulkEntities",
-                           "UpdateLineage"
+                           "UpdateLineage", "ClassificationDefs"
                            ])
 
     wb = load_workbook(temp_path)
@@ -93,6 +94,51 @@ def test_excel_typeDefs_entityTypes():
     assert("entityDefs" in results)
     assert(len(results["entityDefs"]) == 1)
     assert(results["entityDefs"][0]["attributeDefs"][0]["name"] == "attrib1")
+
+    remove_workbook(temp_filepath)
+
+
+def test_excel_typeDefs_entityTypes_superTypes():
+    temp_filepath = "./temp_test_typeDefs_entityTypesWithSuperTypes.xlsx"
+    ec = ExcelConfiguration()
+    reader = ExcelReader(ec)
+    headers = ExcelReader.TEMPLATE_HEADERS["EntityDefs"] + ['Entity superTypes']
+    # "Entity TypeName", "name", "description",
+    # "isOptional", "isUnique", "defaultValue",
+    # "typeName", "displayName", "valuesMinCount",
+    # "valuesMaxCount", "cardinality", "includeInNotification",
+    # "indexType", "isIndexable"
+    json_rows = [
+        ["demoType", "attrib1", "Some desc",
+         "True", "False", None,
+         "string", None, None,
+         None, None, None,
+         None, None, "DataSet;Blah"
+         ],
+         ["demoType", "attrib2", "Some desc",
+         "True", "False", None,
+         "string", None, None,
+         None, None, None,
+         None, None, "Asset"
+         ],
+         ["demoType", "attrib3", "Some desc",
+         "True", "False", None,
+         "string", None, None,
+         None, None, None,
+         None, None, None
+         ]
+    ]
+
+    setup_workbook_custom_sheet(
+        temp_filepath, "EntityDefs", headers, json_rows)
+
+    results = reader.parse_entity_defs(temp_filepath)
+
+    assert("entityDefs" in results)
+    assert(len(results["entityDefs"]) == 1)
+    superTypes = results["entityDefs"][0]["superTypes"]
+    assert( len(superTypes) == 3 )
+    assert( set(superTypes) == set(["DataSet", "Blah", "Asset"]) )
 
     remove_workbook(temp_filepath)
 
@@ -275,17 +321,17 @@ def test_excel_column_lineage():
     setup_workbook(temp_filepath, "ColumnsLineage", max_cols_cl, json_rows_col)
 
     atlas_types = column_lineage_scaffold("demo")
-    
+
     table_entities = reader.parse_table_lineage(temp_filepath)
 
     # For column mappings, table_entities do not contain columnMapping
     assert(all(["columnMapping" not in e.attributes for e in table_entities]))
 
-    column_entities = reader.parse_column_lineage(temp_filepath, 
-        table_entities,
-        atlas_types, 
-        use_column_mapping= True
-    )
+    column_entities = reader.parse_column_lineage(temp_filepath,
+                                                  table_entities,
+                                                  atlas_types,
+                                                  use_column_mapping=True
+                                                  )
 
     try:
         table1 = None
@@ -295,31 +341,37 @@ def test_excel_column_lineage():
         table1_t00 = None
         table0_t00 = None
         col_lineage_process = None
-        table_lookup = {e.name:e for e in table_entities}
-        column_lookup = {e.name:e for e in column_entities}
-        
-        # We have five columns (t00 > t00) + ((tA + tB) > tcombo) 
+        table_lookup = {e.name: e for e in table_entities}
+        column_lookup = {e.name: e for e in column_entities}
+
+        # We have five columns (t00 > t00) + ((tA + tB) > tcombo)
         # and two processes
         assert(len(column_entities) == 7)
 
         # Because of column mappings is TRUE, table entities are modified
         assert("columnMapping" in table_lookup["proc01"].attributes)
-        resulting_col_map = json.loads(table_lookup["proc01"].attributes["columnMapping"])[0]
+        resulting_col_map = json.loads(
+            table_lookup["proc01"].attributes["columnMapping"])[0]
         expected_col_map = {
-            "DatasetMapping":{"Source":"table0", "Sink":"table1"},
-            "ColumnMapping":[
-                {"Source":"t00","Sink":"t00"},
-                {"Source":"tA","Sink":"tcombo"},
-                {"Source":"tB","Sink":"tcombo"}
+            "DatasetMapping": {"Source": "table0", "Sink": "table1"},
+            "ColumnMapping": [
+                {"Source": "t00", "Sink": "t00"},
+                {"Source": "tA", "Sink": "tcombo"},
+                {"Source": "tB", "Sink": "tcombo"}
             ]
         }
-        assert(resulting_col_map["DatasetMapping"] == expected_col_map["DatasetMapping"])
+        assert(resulting_col_map["DatasetMapping"]
+               == expected_col_map["DatasetMapping"])
         assert(len(resulting_col_map["ColumnMapping"]) == 3)
-        assert(resulting_col_map["ColumnMapping"][0] in expected_col_map["ColumnMapping"])
-        assert(resulting_col_map["ColumnMapping"][1] in expected_col_map["ColumnMapping"])
-        assert(resulting_col_map["ColumnMapping"][2] in expected_col_map["ColumnMapping"])
+        assert(resulting_col_map["ColumnMapping"][0]
+               in expected_col_map["ColumnMapping"])
+        assert(resulting_col_map["ColumnMapping"][1]
+               in expected_col_map["ColumnMapping"])
+        assert(resulting_col_map["ColumnMapping"][2]
+               in expected_col_map["ColumnMapping"])
     finally:
         remove_workbook(temp_filepath)
+
 
 def test_excel_update_lineage():
     temp_filepath = "./temp_test_excel_updateLineage.xlsx"
@@ -331,8 +383,8 @@ def test_excel_update_lineage():
     # Same as main test
     json_rows = [
         [
-        "demo_table", "demotarget", "demo_table2", "demosource",
-         "proc01", "procqual01", "Process2"
+            "demo_table", "demotarget", "demo_table2", "demosource",
+            "proc01", "procqual01", "Process2"
         ]
     ]
 
@@ -346,6 +398,7 @@ def test_excel_update_lineage():
     finally:
         remove_workbook(temp_filepath)
 
+
 def test_excel_classification_defs():
     temp_filepath = "./temp_test_excel_classificationDefs.xlsx"
     ec = ExcelConfiguration()
@@ -356,8 +409,8 @@ def test_excel_classification_defs():
     # Same as main test
     json_rows = [
         [
-        "testClassification", None, "This is my classification"
-        "testClassification2", "test;test2", "This is my classification2"
+            "testClassification", None, "This is my classification"
+            "testClassification2", "test;test2", "This is my classification2"
         ]
     ]
 

--- a/tests/unit/readers/test_excel.py
+++ b/tests/unit/readers/test_excel.py
@@ -345,3 +345,30 @@ def test_excel_update_lineage():
         assert(len(results) == 1)
     finally:
         remove_workbook(temp_filepath)
+
+def test_excel_classification_defs():
+    temp_filepath = "./temp_test_excel_classificationDefs.xlsx"
+    ec = ExcelConfiguration()
+    reader = ExcelReader(ec)
+
+    headers = ExcelReader.TEMPLATE_HEADERS["ClassificationDefs"]
+
+    # Same as main test
+    json_rows = [
+        [
+        "testClassification", None, "This is my classification"
+        "testClassification2", "test;test2", "This is my classification2"
+        ]
+    ]
+
+    setup_workbook_custom_sheet(
+        temp_filepath, "ClassificationDefs", headers, json_rows)
+
+    results = reader.parse_classification_defs(temp_filepath)
+
+    try:
+        assert(len(results) == 1)
+        assert("classificationDefs" in results)
+        assert(len(results["classificationDefs"]) == 1)
+    finally:
+        remove_workbook(temp_filepath)

--- a/tests/unit/readers/test_reader.py
+++ b/tests/unit/readers/test_reader.py
@@ -210,3 +210,26 @@ def test_bulk_entity_with_experts_owners():
     assert(len(both["Expert"]) == 2)
     assert("contacts" not in no_contacts)
     
+def test_parse_classification_defs():
+    rc =ReaderConfiguration()
+    reader = Reader(rc)
+
+    json_rows = [
+        {"classificationName": "testClassification", "entityTypes": None, "description": "This is my classification"},
+        {"classificationName": "testClassification2", "entityTypes": "", "description": "This is my classification2"},
+        {"classificationName": "testClassification3", "entityTypes": "DataSet;Process", "description": "This is my classification3"},
+        {"classificationName": "testClassification4", "entityTypes": "DataSet;", "description": "This is my classification4"}
+    ]
+
+    parsed = reader.parse_classification_defs(json_rows)
+
+    results = parsed["classificationDefs"]
+
+
+    assert(len(results) == 4)
+    assert("description" in results[0])
+    assert(results[0]["name"] == "testClassification")
+    assert(len(results[0]["entityTypes"]) == 0)
+    assert(len(results[1]["entityTypes"]) == 0)
+    assert(len(results[2]["entityTypes"]) == 2)
+    assert(len(results[3]["entityTypes"]) == 1)


### PR DESCRIPTION
Closes #107 with support for the EntityDefs reader / excel reader to have a superType defined for the given entity type. Users may add the column `Entity superTypes` and provide a semi-colon (default) delimited list of types. Best practice is to list all super types in one cell for the first attribute being defined the remaining should be left blank. However, you could add one super type on each line if you prefer. The results will be a cumulative superType set for all superTypes mentioned.

Closes #70 by adding a ClassificationDef tab to the excel template and supporting the classification name, entityTypes, and description fields by default.  However, any valid attribute on the AtlasClassificationTypeDef schema can be added as a column to the spreadsheet and it will be passed into the classification def json.