### PR TITLE
Add Support for Glossary Terms / Meanings in Excel / Readers

### DIFF
--- a/tests/unit/readers/test_excel.py
+++ b/tests/unit/readers/test_excel.py
@@ -252,6 +252,53 @@ def test_excel_bulkEntities_dynamicAttributes():
         remove_workbook(temp_filepath)
 
 
+def test_excel_bulkEntities_meanings_relationships():
+    temp_filepath = "./temp_test_excel_bulkEntitieswithMeanings.xlsx"
+    ec = ExcelConfiguration()
+    reader = ExcelReader(ec)
+
+    headers = ExcelReader.TEMPLATE_HEADERS["BulkEntities"] + \
+        ["[Relationship] meanings"]
+    # "typeName", "name",
+    # "qualifiedName", "classifications"
+    # "[Relationship] meanings"
+    json_rows = [
+        ["demoType", "entityNameABC",
+         "qualifiedNameofEntityNameABC", None,
+         None
+         ],
+        ["demoType", "entityNameGHI",
+         "qualifiedNameofEntityNameGHI", None,
+         "termA"
+         ],
+         ["demoType", "entityNameXYZ",
+         "qualifiedNameofEntityNameXYZ", None,
+         "term1;term2"
+         ]
+    ]
+
+    setup_workbook_custom_sheet(
+        temp_filepath, "BulkEntities", headers, json_rows)
+
+    results = reader.parse_bulk_entities(temp_filepath)
+
+    try:
+        abc = results["entities"][0]
+        ghi = results["entities"][1]
+        xyz = results["entities"][2]
+
+        assert("meanings" not in abc["relationshipAttributes"])
+        assert("meanings" in ghi["relationshipAttributes"])
+        ghi_terms = ghi["relationshipAttributes"]["meanings"]
+        xyz_terms = xyz["relationshipAttributes"]["meanings"]
+
+        assert(len(ghi_terms) == 1)
+        assert(len(xyz_terms) == 2)
+
+    finally:
+        remove_workbook(temp_filepath)
+
+
 def test_excel_table_lineage():
     temp_filepath = "./temp_test_excel_table_lineage.xlsx"
     ec = ExcelConfiguration()

--- a/tests/unit/readers/test_reader.py
+++ b/tests/unit/readers/test_reader.py
@@ -87,6 +87,35 @@ def test_parse_bulk_entities_with_relationships():
     assert("table" not in col2["relationshipAttributes"])
 
 
+def test_parse_bulk_entities_with_terms():
+    rc = ReaderConfiguration()
+    reader = Reader(rc)
+    # "typeName", "name",
+    # "qualifiedName", "classifications",
+    # "[Relationship] table"
+    json_rows = [
+        {"typeName": "demo_table", "name": "entityNameABC",
+         "qualifiedName": "qualifiedNameofEntityNameABC", "classifications": None,
+         "[Relationship] meanings": "My Term;abc"
+         },
+         {"typeName": "demo_table", "name": "entityNameDEF",
+         "qualifiedName": "qualifiedNameofEntityNameDEF", "classifications": None,
+         "[Relationship] meanings": None
+         }
+    ]
+    results = reader.parse_bulk_entities(json_rows)
+    ae1 = results["entities"][0]
+    ae2 = results["entities"][1]
+    
+    assert("meanings" in ae1["relationshipAttributes"])
+    assert("meanings" not in ae2["relationshipAttributes"])
+    ae1_meanings = ae1["relationshipAttributes"]["meanings"]
+    
+    assert(len(ae1_meanings) == 2)
+    ae1_meanings_qns = set([e["uniqueAttributes"]["qualifiedName"] for e in ae1_meanings ])
+    assert(set(["My Term@Glossary", "abc@Glossary"]) == ae1_meanings_qns)
+
+
 def test_parse_entity_defs():
     rc = ReaderConfiguration()
     reader = Reader(rc)


### PR DESCRIPTION
Users may now add a [Relationship] meanings column and it takes in a delimited set of terms to be added to the entity. Including a term like 'order id' in the `[Relationship] meanings` column, the package assumes:
* The type has a relationship attribute called meanings.
* The term already exists in your data catalog
* The term exists in the default Glossary.
* The term is case sensitive.
* The case sensitive term can be concatenated with '@Glossary' to generate the qualified name.

Advanced users may consider modifying the output of the reader to address these assumptions.