### PR TITLE
Feature/excel config and cli

### DIFF
--- a/pyapacheatlas/__main__.py
+++ b/pyapacheatlas/__main__.py
@@ -2,15 +2,25 @@ import argparse
 import configparser
 
 if __name__ == "__main__":
+    """
+    This is an experimental feature that will allow users to make the excel
+    template directly from the CLI rather than instantiating an ExcelReader
+    in the Python shell.
+
+    Use `--config` to provide a config.ini file with a `[DEFAULT]` section
+    header and specify any customizations. See `ExcelReader.make_template`
+    for list of possible parameters / configuration settings.
+    """
     from .readers import ExcelConfiguration, ExcelReader
     from . import __version__
     parser = argparse.ArgumentParser()
     parser.add_argument("--make-template", help="Indicates where the excel template should be created")
     parser.add_argument("-c", "--config", help="The location of the configuration file")
+    parser.add_argument("-cs", "--config-section", help="The config file's section header to be used. Defaults to DEFAULT", default="DEFAULT")
     parser.add_argument("--version", help="Display the version of your PyApacheAtlas package",action="store_true")
     args = parser.parse_args()
 
-    config = None
+    config = {}
     if args.version:
         print(__version__)
         exit(0)
@@ -20,5 +30,5 @@ if __name__ == "__main__":
         config.read(args.config)
 
     if args.make_template:
-        print('Made it here')
-        ExcelReader.make_template(args.make_template)
+        ExcelReader.make_template(args.make_template, **config[args.config_section])
+        print(f"Template successfully written to {args.make_template}")

--- a/pyapacheatlas/__main__.py
+++ b/pyapacheatlas/__main__.py
@@ -1,0 +1,24 @@
+import argparse
+import configparser
+
+if __name__ == "__main__":
+    from .readers import ExcelConfiguration, ExcelReader
+    from . import __version__
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--make-template", help="Indicates where the excel template should be created")
+    parser.add_argument("-c", "--config", help="The location of the configuration file")
+    parser.add_argument("--version", help="Display the version of your PyApacheAtlas package",action="store_true")
+    args = parser.parse_args()
+
+    config = None
+    if args.version:
+        print(__version__)
+        exit(0)
+    
+    if args.config:
+        config = configparser.ConfigParser()
+        config.read(args.config)
+
+    if args.make_template:
+        print('Made it here')
+        ExcelReader.make_template(args.make_template)

--- a/setup.py
+++ b/setup.py
@@ -65,7 +65,8 @@ def setup_package():
             "Operating System :: OS Independent",
         ],
         python_requires='>=3.6',
-        long_description=LONG_DESCRIPTION
+        long_description=LONG_DESCRIPTION,
+        options={'console_scripts':{"pyapacheatlas":"pyapacheatlas:main"}}
     )
 
 if __name__ == "__main__":

--- a/tests/unit/readers/test_excel.py
+++ b/tests/unit/readers/test_excel.py
@@ -31,6 +31,76 @@ def test_verify_template_sheets():
         wb.close()
         os.remove(temp_path)
 
+def test_verify_custom_template_sheets():
+    # Setup
+    temp_path = "./temp_customizesheetnames.xlsx"
+    ExcelReader.make_template(temp_path,
+    bulkEntity_sheet="alpha",
+    updateLineage_sheet="beta",
+    columnMapping_sheet="gamma",
+    entityDef_sheet="delta",
+    classificationDef_sheet="epsilon",
+    table_sheet="zeta",
+    column_sheet="eta"
+    )
+
+    # Expected
+    expected_sheets = set(["alpha", "beta",
+                           "gamma", "delta",
+                           "epsilon", "zeta",
+                           "eta"
+                           ])
+
+    wb = load_workbook(temp_path)
+    difference = set(wb.sheetnames).symmetric_difference(expected_sheets)
+    try:
+        assert(len(difference) == 0)
+    finally:
+        wb.close()
+        os.remove(temp_path)
+
+def test_custom_template_header_prefix():
+    # Setup
+    temp_path = "./test_custom_template_header_prefix.xlsx"
+    ExcelReader.make_template(temp_path,
+    source_prefix="alpha",
+    target_prefix="beta",
+    process_prefix="gamma",
+    column_transformation_name="delta"
+    )
+    try:
+
+        # Expected
+        FineGrainColumnLineageHeaders = ["beta table", "beta column", "beta classifications",
+                "alpha table", "alpha column", "alpha classifications",
+                "delta"]
+        TablesLineageHeaders = ["beta table", "beta type", "beta classifications",
+                "alpha table", "alpha type", "alpha classifications",
+                "gamma name", "gamma type"]
+        UpdateLineageHeaders = ["beta typeName", "beta qualifiedName", "alpha typeName",
+                "alpha qualifiedName", "gamma name", "gamma qualifiedName",
+                "gamma typeName"]
+        ColumnMappingHeaders = ["alpha qualifiedName", "alpha column", "beta qualifiedName", 
+                "beta column", "gamma qualifiedName", "gamma typeName",
+                "gamma name"]
+        
+        wb = load_workbook(temp_path)
+
+        FineGrainColumnLineageSheet = wb["FineGrainColumnLineage"]
+        assert([str(c.value).strip() for c in FineGrainColumnLineageSheet[1]] == FineGrainColumnLineageHeaders)
+        
+        TablesLineageSheet = wb["TablesLineage"]
+        assert([str(c.value).strip() for c in TablesLineageSheet[1]] == TablesLineageHeaders)
+
+        UpdateLineageSheet = wb["UpdateLineage"]
+        assert([str(c.value).strip() for c in UpdateLineageSheet[1]] == UpdateLineageHeaders)
+
+        ColumnMappingSheet = wb["ColumnMapping"]
+        assert([str(c.value).strip() for c in ColumnMappingSheet[1]] == ColumnMappingHeaders)
+        
+    finally:
+        wb.close()
+        os.remove(temp_path)
 
 def setup_workbook_custom_sheet(filepath, sheet_name, headers, json_rows):
     wb = Workbook()


### PR DESCRIPTION
Supporting a more expressive excel reader make_template that supports a set of configurations being passed into it.

In addition, users can now use the CLI to make the template `python -m pyapacheatlas --make-template ./path/to/output.xlsx` and specify an optional `--config config.ini` to customize the template.

Closes #143  and closes #124