### PR TITLE
Supporting customAttributes in Excel Upload

### DIFF
--- a/pyapacheatlas/readers/reader.py
+++ b/pyapacheatlas/readers/reader.py
@@ -111,7 +111,7 @@ class Reader(LineageMixIn):
             A dictionary containing 'attributes' and 'relationshipAttributes'
         :rtype: dict(str, dict(str,str))
         """
-        output = {"attributes": {}, "relationshipAttributes": {}, "root":{}}
+        output = {"attributes": {}, "relationshipAttributes": {}, "root":{}, "custom":{}}
         for column_name, cell_value in row.items():
             # Remove the required attributes so they're not double dipping.
             if column_name in ignore:
@@ -148,7 +148,7 @@ class Reader(LineageMixIn):
                 output["relationshipAttributes"].update(
                     {cleaned_key: min_reference}
                 )
-            # TODO: Add support for Business, Custom
+            # TODO: Add support for Business
             elif column_name.startswith("[root]"):
                 # This is a root level attribute
                 cleaned_key = column_name.replace("[root]", "").strip()
@@ -166,6 +166,10 @@ class Reader(LineageMixIn):
 
                 output["root"].update( {cleaned_key: output_value} )
 
+            elif column_name.startswith("[custom]"):
+                cleaned_key = column_name.replace("[custom]", "").strip()
+                
+                output["custom"].update( {cleaned_key: cell_value})
             else:
                 output["attributes"].update({column_name: cell_value})
 
@@ -228,6 +232,9 @@ class Reader(LineageMixIn):
                 if len(row.get("owners", []) or [])>0:
                     owners = [{"id":o} for o in row.get("owners", "").split(self.config.value_separator) if o != '']
                 entity.contacts = {"Expert": experts, "Owner": owners }
+            
+            if _extracted["custom"]:
+                entity.customAttributes = _extracted["custom"]
 
             existing_entities.update({row["qualifiedName"]: entity})
 

--- a/tests/unit/readers/test_reader.py
+++ b/tests/unit/readers/test_reader.py
@@ -344,3 +344,28 @@ def test_parse_column_mapping():
     secondMap_data_map_exp = {"Source": "pqr://777", "Sink": "def://999"}
     assert(secondMap_col_map == secondMap_col_map_exp)
     assert(secondMap_data_map == secondMap_data_map_exp)
+
+def test_parse_bulk_entities_with_custom_attributes():
+    rc = ReaderConfiguration()
+    reader = Reader(rc)
+    # "typeName", "name",
+    # "qualifiedName",
+    # "[custom] foo", "bar"
+    json_rows = [
+        {"typeName": "demo_table", "name": "entityNameABC",
+         "qualifiedName": "qualifiedNameofEntityNameABC",
+         "[custom] foo": "bar"
+         },
+         {"typeName": "demo_table", "name": "entityNameDEF",
+         "qualifiedName": "qualifiedNameofEntityNameDEF",
+         "[custom] foo": None
+         }
+    ]
+    results = reader.parse_bulk_entities(json_rows)
+    ae1 = results["entities"][0]
+    ae2 = results["entities"][1]
+
+    assert("foo" in ae1["customAttributes"])
+    assert(ae1["customAttributes"]["foo"] == "bar")
+
+    assert("customAttributes" not in ae2)


### PR DESCRIPTION
Users wanting to append custom attributes (map of string) can provide
a column header of `[custom] xyz` and it will add a custom attribute
of xyz to the entity being created.

By design, the custom attributes will overwrite everything in the
custom attributes field. If you're updating, your excel upload will
blow away any existing field in custom attributes and replace it with
whatever you provide in excel.

Closes #153 