### PR TITLE
Minor improvements to MySQL Ingestion sample

### DIFF
--- a/samples/metadataIngest/README.md
+++ b/samples/metadataIngest/README.md
@@ -24,7 +24,6 @@ export MYSQL_INSTANCE_PORT=<port>
 export MYSQL_USERNAME=<username>
 export MYSQL_PASSWORD=<password>
 export MYSQL_INCLUDE_DATABASES=<comma separated list of databases to include>
-export MYSQL_EXCLUDE_DATABASES=<comma separated list of databases to exclude>
 export MYSQL_SERVERINSTANCE_CLOUDORONPREM=<onprem or cloud>
 export MYSQL_SERVERINSTANCE_PROD_OR_OTHER=<dev, qa, prod, etc.>
 export MYSQL_SERVERINSTANCE_CONTACTINFO=<contactinfo>
@@ -85,6 +84,14 @@ table
 ``` sql
 ALTER TABLE city CHANGE id id int not null COMMENT "id of city";
 ```
+
+## Running the Entity Registration script for MySQL
+
+From the command prompt, run the `register_typedef.py`. The result will upload the Custom type 
+definitions for our MySQL Instance > Database > Table > Column, as well as the relationship between them
+defined in `pyapacheatlas_mysql_typedefs_v2.json`
+
+Once the relationships are defined, we're ready to scan our MySQL Instance and ingest the metadata.
 
 ## Running the Custom Ingestion script for MySQL
 

--- a/samples/metadataIngest/mysql_metadata_ingest.py
+++ b/samples/metadataIngest/mysql_metadata_ingest.py
@@ -15,7 +15,6 @@ MYSQL_SERVERINSTANCE_PROD_OR_OTHER = os.environ.get('MYSQL_SERVERINSTANCE_PROD_O
 MYSQL_SERVERINSTANCE_CONTACTINFO = os.environ.get('MYSQL_SERVERINSTANCE_CONTACTINFO','')
 MYSQL_SERVERINSTANCE_COMMENT = os.environ.get('MYSQL_SERVERINSTANCE_COMMENT','')
 MYSQL_INCLUDE_DATABASES = os.environ.get('MYSQL_INCLUDE_DATABASES','')
-MYSQL_EXCLUDE_DATABASES = os.environ.get('MYSQL_EXCLUDE_DATABASES','')
 
 class AtlasMySQL:
   guid_count = 0
@@ -144,6 +143,7 @@ def scan_databases(conn, atlas_mysql):
     databases = cursor.fetchall()
     for database in databases:
         if database[0] in MYSQL_INCLUDE_DATABASES:
+            print(f'{database[0]} is included')
             database_fqn = f'{atlas_mysql.instance.qualifiedName}{database[0]}/'
             db = atlas_mysql.add_atlas_db(database, database_fqn)
             db.addRelationship(instance = atlas_mysql.instance)


### PR DESCRIPTION
Updates:
1. Removed `MYSQL_EXCLUDE_DATABASES` environment variable as the ingestion script does not use it (filtering is done on `MYSQL_INCLUDE_DATABASES` [here](https://github.com/wjohnson/pyapacheatlas/blob/96d671d9a161a44f32542f9f4ef069adc8b4f676/samples/metadataIngest/mysql_metadata_ingest.py#L146)
2.  Updated readme to include instructions to run [register_typedef.py](https://github.com/wjohnson/pyapacheatlas/blob/master/samples/metadataIngest/register_typedef.py) before [mysql_metadata_ingest.py](https://github.com/wjohnson/pyapacheatlas/blob/master/samples/metadataIngest/mysql_metadata_ingest.py) - otherwise ingestion fails due to missing Custom Types