### PR TITLE
Closes #188 by deprecating TablesLineage and FineGrainColumnLineage

### DIFF
--- a/pyapacheatlas/__main__.py
+++ b/pyapacheatlas/__main__.py
@@ -25,6 +25,11 @@ if __name__ == "__main__":
         help="The config file's section header to be used. Defaults to DEFAULT",
         default="DEFAULT")
     parser.add_argument(
+        "-de", "--include-deprecated",
+        help="Include deprecated tabs in the excel template",
+        action="store_true"
+    )
+    parser.add_argument(
         "--version",
         help="Display the version of your PyApacheAtlas package",
         action="store_true")
@@ -43,6 +48,9 @@ if __name__ == "__main__":
             raise RuntimeError(
                 f"In your config.ini, please specify a {args.config_section} section or update your --config-section parameter.")
         template_config = config[args.config_section]
+    
+    if args.include_deprecated:
+        template_config["include_deprecated"] = args.include_deprecated
 
     if args.make_template:
         ExcelReader.make_template(args.make_template, **template_config)

--- a/pyapacheatlas/readers/excel.py
+++ b/pyapacheatlas/readers/excel.py
@@ -480,6 +480,10 @@ class ExcelReader(Reader):
         :param str columnMapping_sheet: Defaults to "ColumnMapping"
         :param str entityDef_sheet: Defaults to "EntityDefs"
         :param str classificationDef_sheet: Defaults to "ClassificationDefs"
+        :param bool include_deprecated:
+            Set to True if you want to include tabs that have been deprecated.
+            For this release, it includes TablesLineage and
+            FineGrainColumnLineage.
         :param str table_sheet: Defaults to "TablesLineage"
         :param str column_sheet: Defaults to "FineGrainColumnLineage"
         :param str source_prefix:
@@ -495,6 +499,7 @@ class ExcelReader(Reader):
             Defaults to "transformation" and identifies the column that
             represents the transformation for a specific column.
         """
+        include_deprecated = kwargs.get("include_deprecated", False)
         wb = Workbook()
         bulkEntitiesSheet = wb.active
         bulkEntitiesSheet.title = kwargs.get(
@@ -507,10 +512,11 @@ class ExcelReader(Reader):
             kwargs.get("entityDef_sheet", "EntityDefs"))
         classificationDefsSheet = wb.create_sheet(kwargs.get(
             "classificationDef_sheet", "ClassificationDefs"))
-        tablesSheet = wb.create_sheet(
-            kwargs.get("table_sheet", "TablesLineage"))
-        columnsSheet = wb.create_sheet(kwargs.get(
-            "column_sheet", "FineGrainColumnLineage"))
+        if include_deprecated:
+            tablesSheet = wb.create_sheet(
+                kwargs.get("table_sheet", "TablesLineage"))
+            columnsSheet = wb.create_sheet(kwargs.get(
+                "column_sheet", "FineGrainColumnLineage"))
 
         # Supporting changing the default headers on select pages
         header_changes = {}
@@ -546,12 +552,13 @@ class ExcelReader(Reader):
             UpdateLineageHeaders = Reader.TEMPLATE_HEADERS["UpdateLineage"]
             ColumnMappingHeaders = Reader.TEMPLATE_HEADERS["ColumnMapping"]
 
-        ExcelReader._update_sheet_headers(
-            FineGrainColumnLineageHeaders, columnsSheet
-        )
-        ExcelReader._update_sheet_headers(
-            TablesLineageHeaders, tablesSheet
-        )
+        if include_deprecated:
+            ExcelReader._update_sheet_headers(
+                FineGrainColumnLineageHeaders, columnsSheet
+            )
+            ExcelReader._update_sheet_headers(
+                TablesLineageHeaders, tablesSheet
+            )
         ExcelReader._update_sheet_headers(
             Reader.TEMPLATE_HEADERS["EntityDefs"], entityDefsSheet
         )


### PR DESCRIPTION
tabs in the Excel Template. Users can still generate a template
with these tabs but they must include `--include-deprecated` in the
`--make-template` CLI command or `include_deprecated=True` in the
`make_template` method.