### PR TITLE
Updating sample to avoid deprecated feature

### DIFF
--- a/samples/excel/README.md
+++ b/samples/excel/README.md
@@ -61,12 +61,17 @@ There are four key features of the PyApacheAtlas package with respect to the Exc
   * You want to create a "process entity" that represents the process that ties the two tables together.
   * In addition, you want to use the Azure Purview Column Mapping / Column Lineage UI feature.
   * You'll do this across the `UpdateLineage` and `ColumnMapping` tabs.
+* **Create Entities and Lineage From Scratch**
+  * [Custom Table and Column Lineage](./excel_custom_table_column_lineage.py)
+  * You want to create your tables with schema and assign lineage between those tables.
+  * You'll do this across the `BulkEntities` and `UpdateLineage` tabs.
 * **Creating Custom DataSet Types**
   * [Custom Type Excel Sample](./excel_custom_type_and_entity_upload.py)
   * You have a custom dataset type you want to create with many attributes.
   * You want to upload an entity using that custom type as well.
-* **Hive Bridge Style Table and Column Lineage**
-  * [Custom Table and Column Lineage Excel Sample](./excel_custom_table_column_lineage.py)
+* **(Deprecated) Hive Bridge Style Table and Column Lineage**
+  * [Hive Style Table and Column Lineage Excel Sample](./hive_style_table_column_lineage.py)
+  * Deprecation Warning: This example uses deprecated features which will be removed eventually.
   * You are willing to use a custom type to capture more data about lineage.
   * You are interested in capturing more complex column level lineage.
   * None of the entities you want to upload exist in your catalog.

--- a/samples/excel/excel_custom_table_column_lineage.py
+++ b/samples/excel/excel_custom_table_column_lineage.py
@@ -1,85 +1,135 @@
 import json
 import os
 
-import openpyxl
 from openpyxl import Workbook
 from openpyxl import load_workbook
 
 # PyApacheAtlas packages
 # Connect to Atlas via a Service Principal
 from pyapacheatlas.auth import ServicePrincipalAuthentication
-from pyapacheatlas.core import PurviewClient  # Communicate with your Atlas server
-from pyapacheatlas.scaffolding import column_lineage_scaffold  # Create dummy types
-# Read in the populated excel file.
-# Customize header prefixes (e.g. "Sink" rather than "Target") and sheet names
+from pyapacheatlas.core import PurviewClient, AtlasEntity
 from pyapacheatlas.readers import ExcelConfiguration, ExcelReader
-from pyapacheatlas.core.whatif import WhatIfValidator  # To do what if analysis
 
 
 def fill_in_workbook(filepath, excel_config):
     # You can safely ignore this function as it just
     # populates the excel spreadsheet.
     wb = load_workbook(file_path)
-    table_sheet = wb[excel_config.table_sheet]
-    columns_sheet = wb[excel_config.column_sheet]
+    entityDef_sheet = wb[excel_config.entityDef_sheet]
+    updateLineage_sheet = wb[excel_config.updateLineage_sheet]
+    mapping_sheet = wb[excel_config.columnMapping_sheet]
+    bulkEntity_sheet = wb[excel_config.bulkEntity_sheet]
 
-    # TABLE Sheet SCHEMA
-    # "Target Table", "Target Type", "Target Classifications",
-    # "Source Table", "Source Type", "Source Classifications",
-    # "Process Name", "Process Type"
-    # LIMITATION: Does not support multiple outputs from same process
-    tables_to_load = [
-        ["DestTable01", "demo_table", None, "SourceTable01",
-            "demo_table", None, "Daily_ETL", "demo_process"],
-        ["DestTable01", "demo_table", None, "SourceTable02",
-            "demo_table", None, "Daily_ETL", "demo_process"],
-        ["DestTable02", "demo_table", None, "SourceTable03",
-            "demo_table", None, "Weekly_ETL", "demo_process"],
-        ["DestTable03", "demo_table", None, None, None,
-            None, "Stored_Proc:Do_Something", "demo_process"]
+    # BULK Sheet SCHEMA
+    #"typeName", "name", "qualifiedName"
+    # Adding a couple columns to show the power of this sheet
+    # [Relationship] table, type
+    entities_to_load = [
+        ["hive_table", "hivetable01", "paa://hivetable01withcols",
+            None, None],
+        ["hive_column", "columnA", "paa://hivetable01withcols#colA",
+            'paa://hivetable01withcols', 'string'],
+        ["hive_column", "columnB", "paa://hivetable01withcols#colB",
+            'paa://hivetable01withcols', 'long'],
+        ["hive_column", "columnC", "paa://hivetable01withcols#colC",
+            'paa://hivetable01withcols', 'int'],
+        ["hive_table", "hivetable02withcols", "paa://hivetable02withcols",
+            None, None],
+        ["hive_column", "columnA", "paa://hivetable02withcols#colA",
+            'paa://hivetable02withcols', 'string'],
+        ["hive_column", "columnB", "paa://hivetable02withcols#colB",
+            'paa://hivetable02withcols', 'long'],
+        ["hive_column", "columnC", "paa://hivetable02withcols#colC",
+            'paa://hivetable02withcols', 'int']
     ]
-    # COLUMNS Sheet SCHEMA
-    # "Target Table", "Target Column", "Target Classifications",
-    # "Source Table", "Source Column", "Source Classifications",
-    # "Transformation"
-    columns_to_load = [
-        ["DestTable01", "dest_c01", None, "SourceTable01", "source_c01",
-         None, None],
-        ["DestTable01", "dest_c02", None, "SourceTable01", "source_c02",
-         None, None],
-        # Demonstrate the ability to merge multiple columns
-        ["DestTable01", "dest_combo01", None, "SourceTable01",
-            "source_c03", None, "source_c03 + source_c04"],
-        ["DestTable01", "dest_combo01", None, "SourceTable02",
-            "source_c04", None, "source_c03 + source_c04"],
-        # Demonstrate a simple, straightforward table with classifications
-        ["DestTable02", "dest_c03", None, "SourceTable03",
-            "source_c05", "MICROSOFT.PERSONAL.IPADDRESS", None],
-        ["DestTable02", "dest_c04_express", None,
-            None, None, None, "CURRENT_TIMESTAMP()"],
-        # Demonstrate a table with no sources at all
-        ["DestTable03", "dest_c100_express", None,
-            None, None, None, "CURRENT_TIMESTAMP()"],
-        ["DestTable03", "dest_c101_express",
-            None, None, None, None, "RAND(100)"],
-        ["DestTable03", "dest_c102_notransform", None, None, None,
-         None, None],
+
+    # Need to adjust the default header to include our extra attributes
+    bulkEntity_sheet['D1'] = '[Relationship] table'
+    bulkEntity_sheet['E1'] = 'type'
+
+    # Update Lineage Sheet SCHEMA
+    # "Target typeName", "Target qualifiedName", "Source typeName",
+    # "Source qualifiedName", "Process name", "Process qualifiedName",
+    # "Process typeName"
+    lineage_to_update = [
+        ["hive_table", "paa://hivetable02withcols",
+         "hive_table", "paa://hivetable01withcols",
+         "custom_query",
+         "paa://proc_update_lin_hive_tables",
+         "customProcessWithMapping"
+         ]
+    ]
+
+    # Mapping SCHEMA
+    # "Source qualifiedName", "Source column", "Target qualifiedName", 
+    # "Target column", "Process qualifiedName", "Process typeName",
+    # "Process name"
+    mapping_to_update = [
+        ["paa://hivetable01withcols", "columnA", "paa://hivetable02withcols",
+        "columnA", "paa://proc_update_lin_hive_tables", "customProcessWithMapping",
+        "custom_query"
+        ],
+        ["paa://hivetable01withcols", "columnB", "paa://hivetable02withcols",
+        "columnB", "paa://proc_update_lin_hive_tables", "customProcessWithMapping",
+        "custom_query"
+        ],
+        ["paa://hivetable01withcols", "columnC", "paa://hivetable02withcols",
+        "columnC", "paa://proc_update_lin_hive_tables", "customProcessWithMapping",
+        "custom_query"
+        ]        
+    ]
+
+    # EntityDef SCHEMA
+    # "Entity TypeName", "name", "description",
+    # "isOptional", "isUnique", "defaultValue",
+    # "typeName", "displayName", "valuesMinCount",
+    # "valuesMaxCount", "cardinality", "includeInNotification",
+    # "indexType", "isIndexable", Entity superTypes (as an added non-default)
+    entitydef_to_update = [
+        [
+        "customProcessWithMapping", "columnMapping", "stringified json to support mappings in Purview UI",
+        True, None, None,
+        "string", None, None,
+        None, None, None,
+        None, None,
+        "Process"
+        ]
     ]
 
     # Populate the excel template with samples above
-    table_row_counter = 0
-    for row in table_sheet.iter_rows(min_row=2, max_col=8,
-                                     max_row=len(tables_to_load) + 1):
+    ## Bulk Entities
+    entities_row_counter = 0
+    for row in bulkEntity_sheet.iter_rows(min_row=2, max_col=5,
+                                          max_row=len(entities_to_load) + 1):
         for idx, cell in enumerate(row):
-            cell.value = tables_to_load[table_row_counter][idx]
-        table_row_counter += 1
+            cell.value = entities_to_load[entities_row_counter][idx]
+        entities_row_counter += 1
 
-    column_row_counter = 0
-    for row in columns_sheet.iter_rows(min_row=2, max_col=7,
-                                       max_row=len(columns_to_load) + 1):
+    ## Update Lineage
+    table_row_counter = 0
+    for row in updateLineage_sheet.iter_rows(min_row=2, max_col=7,
+                                             max_row=len(lineage_to_update) + 1):
         for idx, cell in enumerate(row):
-            cell.value = columns_to_load[column_row_counter][idx]
-        column_row_counter += 1
+            cell.value = lineage_to_update[table_row_counter][idx]
+        table_row_counter += 1
+    
+    # Update Column Mapping Sheet
+    mapping_row_counter = 0
+    for row in mapping_sheet.iter_rows(min_row=2, max_col=7,
+                                             max_row=len(mapping_to_update) + 1):
+        for idx, cell in enumerate(row):
+            cell.value = mapping_to_update[mapping_row_counter][idx]
+        mapping_row_counter += 1
+
+    # Update Entity Def Sheet
+    entity_def_counter = 0
+    for row in entityDef_sheet.iter_rows(min_row=2, max_col=15,
+                                             max_row=len(entitydef_to_update) + 1):
+        for idx, cell in enumerate(row):
+            cell.value = entitydef_to_update[entity_def_counter][idx]
+        entity_def_counter += 1
+    
+    entityDef_sheet['O1'].value = 'Entity superTypes'
 
     wb.save(file_path)
 
@@ -87,8 +137,10 @@ def fill_in_workbook(filepath, excel_config):
 if __name__ == "__main__":
     """
     This sample provides an end to end sample of reading an excel file,
-    generating a table and column lineage set of entities, and then
-    uploading the entities to your data catalog.
+    generating new table and column entities, creating a custom type that
+    supports Azure Purview's column mapping feature, and creating a
+    custom Process that provides lineage and column mapping between the
+    created entities.
     """
 
     # Authenticate against your Atlas server
@@ -102,73 +154,32 @@ if __name__ == "__main__":
         authentication=oauth
     )
 
-    # Create an empty excel template to be populated
-    file_path = "./atlas_excel_template.xlsx"
+    # SETUP: This is just setting up the excel file for you
+    file_path = "./demo_custom_table_column_lineage.xlsx"
     excel_config = ExcelConfiguration()
     excel_reader = ExcelReader(excel_config)
 
+    # Create an empty excel template to be populated
     excel_reader.make_template(file_path)
-
+    # This is just a helper to fill in some demo data
     fill_in_workbook(file_path, excel_config)
 
-    # Generate the base atlas type defs for the demo of table and column lineage
-    atlas_type_defs = column_lineage_scaffold(
-        "demo", use_column_mapping=True,
-        column_attributes=[{
-            "name": "datatype",
-            "typeName": "string",
-            "isOptional": True,
-            "cardinality": "SINGLE",
-            "valuesMinCount": 1,
-            "valuesMaxCount": 1,
-            "isUnique": False,
-            "isIndexable": False,
-            "includeInNotification": False
-        }]
-    )
-    # Alternatively, you can get all atlas types via...
-    # atlas_type_defs = client.get_all_typedefs()
+    # ACTUAL WORK:
+    # Parse your custom type def
+    typedefs = excel_reader.parse_entity_defs(file_path)
+    # force_update to True so it's easier to repeat this step
+    _ = client.upload_typedefs(typedefs, force_update=True)
+    
+    # First extract the
+    tables_cols = excel_reader.parse_bulk_entities(file_path)
+    table_col_results = client.upload_entities(tables_cols)
 
-    input(">>>>Ready to upload type definitions?")
-    # Upload scaffolded type defs and view the results of upload
-    _upload_typedef = client.upload_typedefs(
-        atlas_type_defs,
-        force_update=True
-    )
-    print(json.dumps(_upload_typedef, indent=2))
+    # This parses our excel file and creates a batch to upload
+    lineage_with_mapping_processes = excel_reader.parse_update_lineage_with_mappings(file_path)
 
-    input(">>>>Review the above results to see what was uploaded.")
+    # This is what is getting sent to your Atlas server
+    lineage_results = client.upload_entities(lineage_with_mapping_processes)
 
-    # Generate the atlas entities!
+    print(json.dumps([table_col_results, lineage_results], indent=2))
 
-    excel_results = excel_reader.parse_table_finegrain_column_lineages(
-        file_path,
-        atlas_type_defs,
-        use_column_mapping=True
-    )
-
-    print("Results from excel transformation")
-    print(json.dumps(excel_results, indent=2))
-
-    input(">>>>Review the above results to see what your excel file contained")
-
-    # Validate What IF
-    whatif = WhatIfValidator(type_defs=atlas_type_defs)
-
-    report = whatif.validate_entities(excel_results)
-
-    if report["total"] > 0:
-        print("There were errors in the provided typedefs")
-        print(report)
-        exit(1)
-    else:
-        print("There were no errors in the excel file")
-
-    input(">>>>Review the what-if validation results above and get ready to upload your entities!")
-
-    # Upload excel file's content to Atlas and view the guid assignments to confirm successful upload
-    uploaded_entities = client.upload_entities(excel_results)
-    print(json.dumps(uploaded_entities, indent=2))
-
-    print("Completed uploads of demo!")
-    # Be sure to clean up the excel file stored in file_path
+    print("Search for 'hivetable01withcols' to see your results.")

--- a/samples/excel/hive_style_table_column_lineage.py
+++ b/samples/excel/hive_style_table_column_lineage.py
@@ -1,0 +1,180 @@
+#########################
+#  DEPRECATION WARNING  
+# This sample uses deprecated features.
+# Consider using excel_custom_table_column_lineage.py instead.
+#########################
+
+import json
+import os
+
+import openpyxl
+from openpyxl import Workbook
+from openpyxl import load_workbook
+
+# PyApacheAtlas packages
+# Connect to Atlas via a Service Principal
+from pyapacheatlas.auth import ServicePrincipalAuthentication
+from pyapacheatlas.core import PurviewClient  # Communicate with your Atlas server
+from pyapacheatlas.scaffolding import column_lineage_scaffold  # Create dummy types
+# Read in the populated excel file.
+# Customize header prefixes (e.g. "Sink" rather than "Target") and sheet names
+from pyapacheatlas.readers import ExcelConfiguration, ExcelReader
+from pyapacheatlas.core.whatif import WhatIfValidator  # To do what if analysis
+
+
+def fill_in_workbook(filepath, excel_config):
+    # You can safely ignore this function as it just
+    # populates the excel spreadsheet.
+    wb = load_workbook(file_path)
+    table_sheet = wb[excel_config.table_sheet]
+    columns_sheet = wb[excel_config.column_sheet]
+
+    # TABLE Sheet SCHEMA
+    # "Target Table", "Target Type", "Target Classifications",
+    # "Source Table", "Source Type", "Source Classifications",
+    # "Process Name", "Process Type"
+    # LIMITATION: Does not support multiple outputs from same process
+    tables_to_load = [
+        ["DestTable01", "demo_table", None, "SourceTable01",
+            "demo_table", None, "Daily_ETL", "demo_process"],
+        ["DestTable01", "demo_table", None, "SourceTable02",
+            "demo_table", None, "Daily_ETL", "demo_process"],
+        ["DestTable02", "demo_table", None, "SourceTable03",
+            "demo_table", None, "Weekly_ETL", "demo_process"],
+        ["DestTable03", "demo_table", None, None, None,
+            None, "Stored_Proc:Do_Something", "demo_process"]
+    ]
+    # COLUMNS Sheet SCHEMA
+    # "Target Table", "Target Column", "Target Classifications",
+    # "Source Table", "Source Column", "Source Classifications",
+    # "Transformation"
+    columns_to_load = [
+        ["DestTable01", "dest_c01", None, "SourceTable01", "source_c01",
+         None, None],
+        ["DestTable01", "dest_c02", None, "SourceTable01", "source_c02",
+         None, None],
+        # Demonstrate the ability to merge multiple columns
+        ["DestTable01", "dest_combo01", None, "SourceTable01",
+            "source_c03", None, "source_c03 + source_c04"],
+        ["DestTable01", "dest_combo01", None, "SourceTable02",
+            "source_c04", None, "source_c03 + source_c04"],
+        # Demonstrate a simple, straightforward table with classifications
+        ["DestTable02", "dest_c03", None, "SourceTable03",
+            "source_c05", "MICROSOFT.PERSONAL.IPADDRESS", None],
+        ["DestTable02", "dest_c04_express", None,
+            None, None, None, "CURRENT_TIMESTAMP()"],
+        # Demonstrate a table with no sources at all
+        ["DestTable03", "dest_c100_express", None,
+            None, None, None, "CURRENT_TIMESTAMP()"],
+        ["DestTable03", "dest_c101_express",
+            None, None, None, None, "RAND(100)"],
+        ["DestTable03", "dest_c102_notransform", None, None, None,
+         None, None],
+    ]
+
+    # Populate the excel template with samples above
+    table_row_counter = 0
+    for row in table_sheet.iter_rows(min_row=2, max_col=8,
+                                     max_row=len(tables_to_load) + 1):
+        for idx, cell in enumerate(row):
+            cell.value = tables_to_load[table_row_counter][idx]
+        table_row_counter += 1
+
+    column_row_counter = 0
+    for row in columns_sheet.iter_rows(min_row=2, max_col=7,
+                                       max_row=len(columns_to_load) + 1):
+        for idx, cell in enumerate(row):
+            cell.value = columns_to_load[column_row_counter][idx]
+        column_row_counter += 1
+
+    wb.save(file_path)
+
+
+if __name__ == "__main__":
+    """
+    This sample provides an end to end sample of reading an excel file,
+    generating a table and column lineage set of entities, and then
+    uploading the entities to your data catalog.
+    """
+
+    # Authenticate against your Atlas server
+    oauth = ServicePrincipalAuthentication(
+        tenant_id=os.environ.get("TENANT_ID", ""),
+        client_id=os.environ.get("CLIENT_ID", ""),
+        client_secret=os.environ.get("CLIENT_SECRET", "")
+    )
+    client = PurviewClient(
+        account_name = os.environ.get("PURVIEW_NAME", ""),
+        authentication=oauth
+    )
+
+    # Create an empty excel template to be populated
+    file_path = "./atlas_excel_template.xlsx"
+    excel_config = ExcelConfiguration()
+    excel_reader = ExcelReader(excel_config)
+
+    excel_reader.make_template(file_path, include_deprecated=True)
+
+    fill_in_workbook(file_path, excel_config)
+
+    # Generate the base atlas type defs for the demo of table and column lineage
+    atlas_type_defs = column_lineage_scaffold(
+        "demo", use_column_mapping=True,
+        column_attributes=[{
+            "name": "datatype",
+            "typeName": "string",
+            "isOptional": True,
+            "cardinality": "SINGLE",
+            "valuesMinCount": 1,
+            "valuesMaxCount": 1,
+            "isUnique": False,
+            "isIndexable": False,
+            "includeInNotification": False
+        }]
+    )
+    # Alternatively, you can get all atlas types via...
+    # atlas_type_defs = client.get_all_typedefs()
+
+    input(">>>>Ready to upload type definitions?")
+    # Upload scaffolded type defs and view the results of upload
+    _upload_typedef = client.upload_typedefs(
+        atlas_type_defs,
+        force_update=True
+    )
+    print(json.dumps(_upload_typedef, indent=2))
+
+    input(">>>>Review the above results to see what was uploaded.")
+
+    # Generate the atlas entities!
+
+    excel_results = excel_reader.parse_table_finegrain_column_lineages(
+        file_path,
+        atlas_type_defs,
+        use_column_mapping=True
+    )
+
+    print("Results from excel transformation")
+    print(json.dumps(excel_results, indent=2))
+
+    input(">>>>Review the above results to see what your excel file contained")
+
+    # Validate What IF
+    whatif = WhatIfValidator(type_defs=atlas_type_defs)
+
+    report = whatif.validate_entities(excel_results)
+
+    if report["total"] > 0:
+        print("There were errors in the provided typedefs")
+        print(report)
+        exit(1)
+    else:
+        print("There were no errors in the excel file")
+
+    input(">>>>Review the what-if validation results above and get ready to upload your entities!")
+
+    # Upload excel file's content to Atlas and view the guid assignments to confirm successful upload
+    uploaded_entities = client.upload_entities(excel_results)
+    print(json.dumps(uploaded_entities, indent=2))
+
+    print("Completed uploads of demo!")
+    # Be sure to clean up the excel file stored in file_path


### PR DESCRIPTION
I need to update the Excel sample that uses TableLineage and FineGrainColumnLineage to reference the `include_deprecated` flag in the `make_template`. In addition, updating the original `excel_custom_table_column_lineage.py` to now be a demonstration of BulkEntities, UpdateLineage, ColumnMappings, EntityTypeDefs tabs.