### PR TITLE
Improve performance when total returned result is small

### DIFF
--- a/pyapacheatlas/core/discovery/purview.py
+++ b/pyapacheatlas/core/discovery/purview.py
@@ -249,6 +249,11 @@ class PurviewDiscoveryClient(AtlasBaseClient):
 
             offset = offset + return_count
 
+            # if the new offset is larger than the total result count, we'll just return to avoid an additional call to the service.
+            # This can increase the performance when the total call number is small
+            if offset > results['@search.count']:
+                return
+
             for sub_result in return_values:
                 try:
                     yield sub_result


### PR DESCRIPTION
Currently the `_search_generator` function will have 2 calls to the service even if the result is small (say 10 results or so). This can be improved by adding additional return statement in the code.