### PR TITLE
Support Biz / Managed Attributes in Excel

### DIFF
--- a/pyapacheatlas/core/entity.py
+++ b/pyapacheatlas/core/entity.py
@@ -131,6 +131,14 @@ class AtlasEntity():
         also update an existing business attribute. You can pass in a parameter
         name and a dict.
 
+        For example:
+        ```python
+        entity.addBusinessAttribute(
+            operations={"expenseCode":"123", "criticality":"low"}
+        )
+        ```
+
+
         Kwargs:
             :param kwarg: The name(s) of the business attribute(s) you're adding.
             :type kwarg: dict

--- a/tests/unit/readers/test_reader.py
+++ b/tests/unit/readers/test_reader.py
@@ -178,9 +178,39 @@ def test_parse_bulk_entities_with_root_labels():
     assert(("status" not in ae1) and "status" in ae2)
     assert(ae2["status"] == "ACTIVE")
 
+def test_parse_bulk_entities_with_businessMeta():
+    rc = ReaderConfiguration()
+    reader = Reader(rc)
+    # "typeName", "name",
+    # "qualifiedName", "classifications",
+    # "[Relationship] table"
+    json_rows = [
+        {"typeName": "demo_table", "name": "entityNameABC",
+         "qualifiedName": "qualifiedNameofEntityNameABC",
+         "[Business][type1] attrib1": None
+         },
+        {"typeName": "demo_column", "name": "col1",
+         "qualifiedName": "col1qn",
+         "[Business][type1] attrib1": "abc"
+         },
+         {"typeName": "demo_column", "name": "col2",
+         "qualifiedName": "col2qn",
+         "[Managed][type2] attrib2": 123
+         }
+    ]
+    results = reader.parse_bulk_entities(json_rows)
+    abc = results["entities"][0]
+    col1 = results["entities"][1]
+    col2 = results["entities"][2]
+
+    assert("type1" in col1["businessAttributes"])
+    assert("type2" in col2["businessAttributes"])
+    col1_type1 = col1["businessAttributes"]["type1"]
+    assert("attrib1" in col1_type1 and col1_type1["attrib1"] == "abc")
+    col2_type2 = col2["businessAttributes"]["type2"]
+    assert("attrib2" in col2_type2 and col2_type2["attrib2"] == 123)
+    
 # TODO: classifications
-# TODO: busines attributes
-# TODO: custom attributes
 
 def test_parse_entity_defs():
     rc = ReaderConfiguration()


### PR DESCRIPTION
This PR closes #237 by enabling the reader and parse_bulk_entities to understand business metadata.

You can include them with a column header of `[Business][typeName] attributeName` or `[Managed][groupName] attributeName`. Both are valid since Atlas would call it BusinessMetadata but Purview calls it Managed attributes í¹