### PR TITLE
Fix bug businessMetadata

### DIFF
--- a/pyapacheatlas/core/client.py
+++ b/pyapacheatlas/core/client.py
@@ -551,7 +551,7 @@ class AtlasClient(AtlasBaseClient):
             # business_Metadata has an underscore so before it can be used in
             # the endpoint, it must be converted to businessMetadata.
             atlas_endpoint = atlas_endpoint + \
-                "{}def".format(type_category.value.replace("_", ""))
+                "{}def".format(type_category.value.replace("_", "").lower())
         elif guid or name:
             atlas_endpoint = atlas_endpoint + "typedef"
         else:


### PR DESCRIPTION
When calling get_typedef with TypeCategory.BUSINESSMEATADATA it generates an endpoint with upper case (businessMetadata) which causes to fails. This fix generate the url with lower cases as "businessmetadata"